### PR TITLE
Inline trivial libraries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,9 +23,7 @@ dependencies {
     implementation(libs.quarkus.reactive.pg.client)
     implementation(libs.quarkus.arc)
     implementation(libs.quarkus.kotlin)
-    implementation(libs.uuid.creator)
     testImplementation(libs.quarkus.junit5)
-    testImplementation(libs.rest.assured)
 }
 
 group = "io.github.gabrielshanahan"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ quarkus = "3.24.5"             # checked: 2026-03-10
 ktfmt = "0.25.0"               # checked: 2026-03-10
 detekt = "1.23.8"              # checked: 2026-03-10
 fluentjdbc = "1.0.0"           # checked: 2026-03-10
-uuid-creator = "6.1.1"         # checked: 2026-03-10
 
 [libraries]
 quarkus-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkus" }
@@ -17,9 +16,7 @@ quarkus-fluentjdbc = { module = "io.quarkiverse.fluentjdbc:quarkus-fluentjdbc", 
 quarkus-reactive-pg-client = { module = "io.quarkus:quarkus-reactive-pg-client" }
 quarkus-arc = { module = "io.quarkus:quarkus-arc" }
 quarkus-kotlin = { module = "io.quarkus:quarkus-kotlin" }
-uuid-creator = { module = "com.github.f4b6a3:uuid-creator", version.ref = "uuid-creator" }
 quarkus-junit5 = { module = "io.quarkus:quarkus-junit5" }
-rest-assured = { module = "io.rest-assured:rest-assured" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/DistributedCoroutineIdentifier.kt
+++ b/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/DistributedCoroutineIdentifier.kt
@@ -1,6 +1,6 @@
 package io.github.gabrielshanahan.scoop.coroutine
 
-import com.github.f4b6a3.uuid.UuidCreator
+import io.github.gabrielshanahan.scoop.util.uuidV7
 
 /**
  * Identifies a distributed coroutine (saga) implementation, with support for horizontal scaling.
@@ -39,7 +39,7 @@ data class DistributedCoroutineIdentifier(val name: String, val instance: String
      *
      * @param name The saga type/handler name
      */
-    constructor(name: String) : this(name, UuidCreator.getTimeOrderedEpoch().toString())
+    constructor(name: String) : this(name, uuidV7().toString())
 }
 
 /**

--- a/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/Capabilities.kt
+++ b/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/Capabilities.kt
@@ -1,6 +1,5 @@
 package io.github.gabrielshanahan.scoop.coroutine.structuredcooperation
 
-import com.github.f4b6a3.uuid.UuidCreator
 import io.github.gabrielshanahan.scoop.coroutine.CooperationScope
 import io.github.gabrielshanahan.scoop.coroutine.CooperationScopeIdentifier
 import io.github.gabrielshanahan.scoop.coroutine.context.CooperationContext
@@ -8,6 +7,7 @@ import io.github.gabrielshanahan.scoop.coroutine.context.emptyContext
 import io.github.gabrielshanahan.scoop.coroutine.renderAsString
 import io.github.gabrielshanahan.scoop.messaging.Message
 import io.github.gabrielshanahan.scoop.messaging.MessageRepository
+import io.github.gabrielshanahan.scoop.util.uuidV7
 import jakarta.enterprise.context.ApplicationScoped
 import java.sql.Connection
 import org.postgresql.util.PGobject
@@ -221,7 +221,7 @@ private class Capabilities(
         context: CooperationContext?,
     ): CooperationRoot {
         val message = messageRepository.insertMessage(connection, topic, payload)
-        val cooperationId = UuidCreator.getTimeOrderedEpoch()
+        val cooperationId = uuidV7()
         val cooperationLineage = listOf(cooperationId)
         messageEventRepository.insertGlobalEmittedEvent(
             connection,

--- a/src/main/kotlin/io/github/gabrielshanahan/scoop/util/UuidV7.kt
+++ b/src/main/kotlin/io/github/gabrielshanahan/scoop/util/UuidV7.kt
@@ -1,0 +1,34 @@
+package io.github.gabrielshanahan.scoop.util
+
+import java.security.SecureRandom
+import java.util.UUID
+
+private val random = SecureRandom()
+
+/** Generates a UUIDv7 (Unix Epoch time-based, with random bits). */
+@Suppress("MagicNumber")
+fun uuidV7(): UUID {
+    val timestamp = System.currentTimeMillis()
+    val randomBytes = ByteArray(10)
+    random.nextBytes(randomBytes)
+
+    // Most significant 64 bits: 48-bit timestamp | 4-bit version (0111) | 12-bit random
+    val msb =
+        (timestamp shl 16) or // 48-bit timestamp in upper bits
+            (0x7000L) or // version 7
+            ((randomBytes[0].toLong() and 0x0F) shl 8) or
+            (randomBytes[1].toLong() and 0xFF)
+
+    // Least significant 64 bits: 2-bit variant (10) | 62-bit random
+    val lsb =
+        ((randomBytes[2].toLong() and 0x3F) or 0x80.toLong() shl 56) or
+            ((randomBytes[3].toLong() and 0xFF) shl 48) or
+            ((randomBytes[4].toLong() and 0xFF) shl 40) or
+            ((randomBytes[5].toLong() and 0xFF) shl 32) or
+            ((randomBytes[6].toLong() and 0xFF) shl 24) or
+            ((randomBytes[7].toLong() and 0xFF) shl 16) or
+            ((randomBytes[8].toLong() and 0xFF) shl 8) or
+            (randomBytes[9].toLong() and 0xFF)
+
+    return UUID(msb, lsb)
+}


### PR DESCRIPTION
## Summary
- Replaced `uuid-creator` with a custom UUIDv7 generator (`UuidV7.kt`), removing an external dependency
- Removed unused `rest-assured` test dependency
- All 86 tests pass

## Test plan
- [x] `./gradlew build` passes (compilation, ktfmt, detekt, 86 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)