### PR TITLE
Bump Quarkus 3.24.5 → 3.32.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.1.20"              # checked: 2026-03-10
-quarkus = "3.24.5"             # checked: 2026-03-10
+quarkus = "3.32.3"             # checked: 2026-03-30
 ktfmt = "0.25.0"               # checked: 2026-03-10
 detekt = "1.23.8"              # checked: 2026-03-10
 fluentjdbc = "1.8.6"           # checked: 2026-03-10

--- a/scoop-quarkus/build.gradle.kts
+++ b/scoop-quarkus/build.gradle.kts
@@ -4,6 +4,24 @@ plugins {
     alias(libs.plugins.quarkus)
 }
 
+// Quarkus BOM enforces Kotlin stdlib 2.3.x, but we need 2.1.x (detekt 1.23 incompatible with 2.3).
+// Only pin Kotlin on compile/runtime classpaths — exclude detekt's own classpath.
+configurations
+    .matching {
+        it.name.startsWith("api") ||
+            it.name.startsWith("implementation") ||
+            it.name.startsWith("compile") ||
+            it.name.startsWith("runtime") ||
+            it.name.startsWith("test")
+    }
+    .configureEach {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.jetbrains.kotlin") {
+                useVersion(libs.versions.kotlin.get())
+            }
+        }
+    }
+
 dependencies {
     api(project(":scoop-core"))
     implementation(platform(libs.quarkus.bom))

--- a/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/PgSubscriberProducer.kt
+++ b/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/PgSubscriberProducer.kt
@@ -146,9 +146,9 @@ class PgSubscriberProducer(
         dataSourceReactiveRuntimeConfig: DataSourceReactiveRuntimeConfig,
         dataSourceReactivePostgreSQLConfig: DataSourceReactivePostgreSQLConfig,
     ) {
-        pgConnectOptions.setCachePreparedStatements(
-            dataSourceReactiveRuntimeConfig.cachePreparedStatements()
-        )
+        dataSourceReactiveRuntimeConfig.cachePreparedStatements().ifPresent {
+            pgConnectOptions.setCachePreparedStatements(it)
+        }
 
         if (dataSourceReactivePostgreSQLConfig.pipeliningLimit().isPresent) {
             pgConnectOptions.setPipeliningLimit(


### PR DESCRIPTION
## Summary

- Bump Quarkus from 3.24.5 to 3.32.3
- Fix `DataSourceReactiveRuntimeConfig.cachePreparedStatements()` API change (`boolean` → `Optional<Boolean>`) in `PgSubscriberProducer`
- Add scoped Kotlin version resolution strategy to prevent Quarkus BOM from forcing Kotlin stdlib 2.3.x (incompatible with detekt 1.23)

## Test plan

- [x] `./gradlew build` passes locally (all tests green)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)