### PR TITLE
Fix null value handling in CooperationContext round-trip

### DIFF
--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/context/CooperationContextModule.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/context/CooperationContextModule.kt
@@ -204,7 +204,6 @@ class CooperationContextModule(private val objectMapper: ObjectMapper) :
                         parser.nextToken()
                         readAsString(parser, sb)
                     }
-                    sb.dropLast(1) // drop trailing comma
                     sb.append('}')
                 }
                 JsonToken.START_ARRAY -> {
@@ -224,7 +223,7 @@ class CooperationContextModule(private val objectMapper: ObjectMapper) :
                 JsonToken.VALUE_NUMBER_FLOAT -> sb.append(parser.numberValue.toString())
                 JsonToken.VALUE_TRUE,
                 JsonToken.VALUE_FALSE -> sb.append(parser.booleanValue.toString())
-                JsonToken.VALUE_NULL -> {}
+                JsonToken.VALUE_NULL -> sb.append("null")
                 JsonToken.FIELD_NAME -> sb.append("\"${parser.text}\":")
                 else -> error("Unsupported token: ${parser.currentToken()}")
             }

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/context/CooperationContextTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/context/CooperationContextTest.kt
@@ -28,6 +28,34 @@ class CooperationContextTest {
     }
 
     @Test
+    fun `test null values are preserved in round-trip`() {
+        val jsonString = """{"key-with-null":null}"""
+        val context = JsonObject(jsonString).mapTo(CooperationContext::class.java)
+        assertEquals(jsonString, objectMapper.writeValueAsString(context))
+    }
+
+    @Test
+    fun `test null values mixed with other values are preserved in round-trip`() {
+        val jsonString = """{"a-before":"a","b-nullable":null,"c-after":"b"}"""
+        val context = JsonObject(jsonString).mapTo(CooperationContext::class.java)
+        assertEquals(jsonString, objectMapper.writeValueAsString(context))
+    }
+
+    @Test
+    fun `test nested null values are preserved in round-trip`() {
+        val jsonString = """{"outer":{"inner":null,"range":null}}"""
+        val context = JsonObject(jsonString).mapTo(CooperationContext::class.java)
+        assertEquals(jsonString, objectMapper.writeValueAsString(context))
+    }
+
+    @Test
+    fun `test null values in arrays are preserved in round-trip`() {
+        val jsonString = """{"items":[1,null,3]}"""
+        val context = JsonObject(jsonString).mapTo(CooperationContext::class.java)
+        assertEquals(jsonString, objectMapper.writeValueAsString(context))
+    }
+
+    @Test
     fun `test everything works as expected`() {
         val jsonString = """{"TestKey":{"value":"test-value"},"unknown-key":"test-value"}"""
         val context = JsonObject(jsonString).mapTo(CooperationContext::class.java)


### PR DESCRIPTION
## Summary
- `readAsString()` in `CooperationContextDeserializer` silently dropped `VALUE_NULL` tokens (empty handler block), producing invalid JSON like `"range":}` instead of `"range":null`
- Fixed by appending the literal string `"null"` for `VALUE_NULL` tokens
- Removed dead `dropLast(1)` call — `StringBuilder.dropLast()` returns a new `CharSequence` without mutating, so the result was silently discarded

## Test plan
- [x] Added test for null-only object round-trip (`{"key-with-null":null}`)
- [x] Added test for null mixed with other values (`{"a-before":"a","b-nullable":null,"c-after":"b"}`)
- [x] Added test for nested null values (`{"outer":{"inner":null,"range":null}}`)
- [x] Added test for null values in arrays (`{"items":[1,null,3]}`)
- [x] All existing CooperationContextTest tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)