### PR TITLE
Overhaul logging: fix levels and add strategic logging

### DIFF
--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/Scoop.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/Scoop.kt
@@ -13,6 +13,7 @@ import io.github.gabrielshanahan.scoop.messaging.PostgresMessageQueue
 import io.github.gabrielshanahan.scoop.messaging.TopicNotifier
 import javax.sql.DataSource
 import org.codejargon.fluentjdbc.api.FluentJdbcBuilder
+import org.slf4j.LoggerFactory
 
 /**
  * Main entry point for creating and using Scoop — the Structured Cooperation library.
@@ -36,6 +37,8 @@ private constructor(
 ) : AutoCloseable {
 
     companion object {
+        private val logger = LoggerFactory.getLogger(Scoop::class.java)
+
         /**
          * Creates a fully-wired Scoop instance from a [DataSource].
          *
@@ -60,6 +63,7 @@ private constructor(
             val messageQueue =
                 PostgresMessageQueue(topicNotifier, capabilities, messageRepository, eventLoop)
 
+            logger.info("Scoop framework initialized")
             return Scoop(messageQueue, capabilities)
         }
 

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
@@ -129,7 +129,7 @@ class EventLoop(
             whileISaySo { repeatCount, saySo ->
                 fluentJdbc.transactional { connection ->
                     try {
-                        logger.info(
+                        logger.debug(
                             "Run number $repeatCount for topic $topic and coroutine ${distributedCoroutine.identifier}"
                         )
                         val coroutineState =
@@ -186,7 +186,7 @@ class EventLoop(
         executor.scheduleWithFixedDelay(
             {
                 try {
-                    logger.info(
+                    logger.debug(
                         "Starting tick for topic $topic and coroutine ${distributedCoroutine.identifier}"
                     )
                     tick(topic, distributedCoroutine)
@@ -266,13 +266,13 @@ class EventLoop(
             )
 
         if (result == null) {
-            logger.info(
+            logger.debug(
                 "[${connection.backendPID()}] " +
                     "No messages for coroutine ${distributedCoroutine.identifier}"
             )
             return null
         } else {
-            logger.info(
+            logger.debug(
                 "[${connection.backendPID()}] " +
                     "Processing message for coroutine " +
                     "${distributedCoroutine.identifier}: " +
@@ -645,7 +645,7 @@ class EventLoop(
                 )
         }
 
-        logger.info(
+        logger.debug(
             "[${connection.backendPID()}] " +
                 "Finished processing message for continuation " +
                 "${cooperativeContinuation.continuationIdentifier}: " +

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/continuation/CooperationContinuation.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/continuation/CooperationContinuation.kt
@@ -14,6 +14,7 @@ import io.github.gabrielshanahan.scoop.coroutine.structuredcooperation.ScopeCapa
 import io.github.gabrielshanahan.scoop.messaging.Message
 import java.sql.Connection
 import org.postgresql.util.PGobject
+import org.slf4j.LoggerFactory
 
 /**
  * Since the lifetime of a [CooperationScope] is exactly the same as the lifetime of the (delimited)
@@ -107,6 +108,10 @@ internal abstract class BaseCooperationContinuation(
     private var stepIteration: Int,
     private var childFailureHandlerIteration: ChildFailureHandlerIteration,
 ) : CooperationContinuation {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(BaseCooperationContinuation::class.java)
+    }
 
     /**
      * Tracks the current step being executed within this continuation. Since suspension points
@@ -276,8 +281,13 @@ internal abstract class BaseCooperationContinuation(
      */
     override fun resumeWith(
         lastStepResult: Continuation.LastStepResult
-    ): Continuation.ContinuationResult =
-        when (suspensionPoint) {
+    ): Continuation.ContinuationResult {
+        logger.debug(
+            "Resuming continuation from {}: coroutine='{}'",
+            suspensionPoint::class.simpleName,
+            distributedCoroutine.identifier,
+        )
+        return when (suspensionPoint) {
             is SuspensionPoint.BeforeFirstStep -> {
                 // Starting fresh - execute the first step in the saga
                 currentStep = suspensionPoint.firstStep
@@ -306,6 +316,7 @@ internal abstract class BaseCooperationContinuation(
                 resumeCoroutine(lastStepResult)
             }
         }
+    }
 
     /**
      * Executes the actual continuation logic with proper exception handling and give-up checking.
@@ -326,6 +337,12 @@ internal abstract class BaseCooperationContinuation(
         return try {
             // Check if we should abandon execution before doing any work
             giveUpIfNecessary()
+
+            logger.debug(
+                "Executing step: coroutine='{}', step='{}'",
+                distributedCoroutine.identifier,
+                currentStep.name,
+            )
 
             // Execute the step logic and check for give-up conditions that arose during execution
             handleFailuresOrResume(lastStepResult).also { giveUpIfNecessary() }
@@ -391,6 +408,11 @@ internal abstract class BaseCooperationContinuation(
     ): Continuation.ContinuationResult =
         when (lastStepResult) {
             is Continuation.LastStepResult.ChildFailed -> {
+                logger.debug(
+                    "Handling child failures: step='{}', iteration={}",
+                    currentStep.name,
+                    childFailureHandlerIteration,
+                )
                 // Increment child failure handler iteration for each failure handling invocation
                 val incrementedIteration = childFailureHandlerIteration.incremented()
                 childFailureHandlerIteration = incrementedIteration
@@ -445,6 +467,10 @@ internal abstract class BaseCooperationContinuation(
     private fun resume(resumeStep: () -> NextStep): Continuation.ContinuationResult =
         if (suspensionPoint is SuspensionPoint.AfterLastStep) {
             // All steps completed - saga is done, don't execute the step
+            logger.debug(
+                "Saga completed all steps: coroutine='{}'",
+                distributedCoroutine.identifier,
+            )
             Continuation.ContinuationResult.Success
         } else {
             // More steps remain - execute this step and suspend to wait for children

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/continuation/RollbackPathContinuation.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/continuation/RollbackPathContinuation.kt
@@ -14,6 +14,7 @@ import io.github.gabrielshanahan.scoop.coroutine.structuredcooperation.ScopeCapa
 import io.github.gabrielshanahan.scoop.messaging.Message
 import java.sql.Connection
 import java.time.Instant
+import org.slf4j.LoggerFactory
 
 /**
  * A continuation for rollback (compensating) execution of saga steps.
@@ -104,6 +105,11 @@ import java.time.Instant
 // TODO: Config
 const val ROLLING_BACK_PREFIX = "Rollback of "
 const val ROLLING_BACK_CHILD_SCOPES_STEP_SUFFIX = " (rolling back child scopes)"
+
+private val rollbackLogger =
+    LoggerFactory.getLogger(
+        "io.github.gabrielshanahan.scoop.coroutine.continuation.RollbackPathContinuation"
+    )
 
 @Suppress("LongParameterList")
 internal class RollbackPathContinuation(
@@ -238,6 +244,12 @@ internal fun DistributedCoroutine.buildRollbackPathContinuation(
             scopeCapabilities,
             originalInstances,
         )
+
+    rollbackLogger.debug(
+        "Built rollback plan: coroutine='{}', rollbackSteps={}",
+        identifier,
+        rollbackSteps.size,
+    )
 
     // Helper: creates a sentinel rollback step for edge cases where we need a valid step reference
     // but have nothing to actually roll back. Builds rollback steps for a single synthetic instance

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/Capabilities.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/Capabilities.kt
@@ -13,6 +13,7 @@ import io.github.gabrielshanahan.scoop.util.uuidV7
 import java.sql.Connection
 import java.time.Instant
 import org.postgresql.util.PGobject
+import org.slf4j.LoggerFactory
 
 /**
  * Represents the root of an independent cooperation hierarchy.
@@ -262,12 +263,18 @@ class Capabilities(
     private val messageEventRepository: MessageEventRepository,
     private val returnValueRepository: ReturnValueRepository,
 ) : ScopeCapabilities, StructuredCooperationCapabilities {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(Capabilities::class.java)
+    }
+
     override fun launchOnGlobalScope(
         connection: Connection,
         topic: String,
         payload: PGobject,
         context: CooperationContext?,
     ): CooperationRoot {
+        logger.debug("Launching message on global scope: topic='{}'", topic)
         val message = messageRepository.insertMessage(connection, topic, payload)
         val cooperationId = uuidV7()
         val cooperationLineage = listOf(cooperationId)
@@ -294,6 +301,13 @@ class Capabilities(
         payload: PGobject,
         additionalContext: CooperationContext?,
     ): Message {
+        logger.debug(
+            "Launching scoped message: topic='{}', coroutine='{}', step='{}'",
+            topic,
+            scope.continuation.continuationIdentifier.distributedCoroutineIdentifier
+                .renderAsString(),
+            scope.continuation.continuationIdentifier.stepName,
+        )
         val message = messageRepository.insertMessage(scope.connection, topic, payload)
 
         messageEventRepository.insertScopedEmittedEvent(
@@ -317,6 +331,7 @@ class Capabilities(
         source: String,
         reason: String,
     ) {
+        logger.debug("Requesting cancellation: source='{}', reason='{}'", source, reason)
         val exception = CancellationRequestedException(reason)
         val cooperationFailure = CooperationFailure.fromThrowable(exception, source)
 
@@ -333,6 +348,7 @@ class Capabilities(
         source: String,
         reason: String,
     ) {
+        logger.debug("Requesting rollback: source='{}', reason='{}'", source, reason)
         val exception = RollbackRequestedException(reason)
         val cooperationFailure = CooperationFailure.fromThrowable(exception, source)
 
@@ -348,6 +364,12 @@ class Capabilities(
         suspendedAt: Instant,
         throwable: Throwable,
     ) {
+        logger.debug(
+            "Emitting rollbacks for child emissions: coroutine='{}', step='{}'",
+            scope.continuation.continuationIdentifier.distributedCoroutineIdentifier
+                .renderAsString(),
+            scope.continuation.continuationIdentifier.stepName,
+        )
         val cooperationFailure =
             CooperationFailure.fromThrowable(
                 ParentSaidSoException(throwable),
@@ -379,6 +401,12 @@ class Capabilities(
             )
 
         if (exceptions.any()) {
+            logger.warn(
+                "Saga giving up due to {} exception(s): coroutine='{}'",
+                exceptions.size,
+                scope.continuation.continuationIdentifier.distributedCoroutineIdentifier
+                    .renderAsString(),
+            )
             throw GaveUpException(exceptions)
         }
     }
@@ -388,6 +416,7 @@ class Capabilities(
         variableName: VariableName,
         value: PGobject,
     ) {
+        logger.debug("Storing return value: variableName='{}'", variableName)
         val handlerName =
             scope.continuation.continuationIdentifier.distributedCoroutineIdentifier.name
 
@@ -404,13 +433,15 @@ class Capabilities(
         scope: CooperationScope,
         variableName: VariableName,
         handlerRegistry: (String) -> Handler<*>,
-    ): Map<Handler<*>, PGobject> =
-        returnValueRepository.getReturnValues(
+    ): Map<Handler<*>, PGobject> {
+        logger.debug("Retrieving return values: variableName='{}'", variableName)
+        return returnValueRepository.getReturnValues(
             scope.connection,
             scope.scopeIdentifier.cooperationLineage,
             variableName,
             handlerRegistry,
         )
+    }
 
     override fun getReturnValue(
         scope: CooperationScope,

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/MessageEventRepository.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/MessageEventRepository.kt
@@ -12,12 +12,17 @@ import java.util.UUID
 import org.codejargon.fluentjdbc.api.FluentJdbc
 import org.intellij.lang.annotations.Language
 import org.postgresql.util.PGobject
+import org.slf4j.LoggerFactory
 
 @Suppress("TooManyFunctions")
 class MessageEventRepository(
     private val jsonbHelper: JsonbHelper,
     private val fluentJdbc: FluentJdbc,
 ) {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(MessageEventRepository::class.java)
+    }
 
     /**
      * Records that a message was emitted on the global scope (breaking cooperation lineage).
@@ -36,6 +41,7 @@ class MessageEventRepository(
         cooperationLineage: List<UUID>,
         context: CooperationContext?,
     ) {
+        logger.debug("Inserting global EMITTED event: messageId={}", messageId)
         fluentJdbc
             .queryOn(connection)
             .update(
@@ -79,6 +85,12 @@ class MessageEventRepository(
         cooperationLineage: List<UUID>,
         context: CooperationContext?,
     ) {
+        logger.debug(
+            "Inserting scoped EMITTED event: messageId={}, coroutine='{}', step='{}'",
+            messageId,
+            coroutineName,
+            stepName,
+        )
         fluentJdbc
             .queryOn(connection)
             .update(
@@ -137,6 +149,7 @@ class MessageEventRepository(
         cooperationLineage: List<UUID>,
         exception: CooperationFailure,
     ) {
+        logger.debug("Inserting ROLLBACK_EMITTED event for lineage")
         val lineageArray = connection.createArrayOf("uuid", cooperationLineage.toTypedArray())
 
         fluentJdbc
@@ -233,6 +246,7 @@ class MessageEventRepository(
         cooperationLineage: List<UUID>,
         exception: CooperationFailure,
     ) {
+        logger.debug("Inserting CANCELLATION_REQUESTED event")
         val lineageArray = connection.createArrayOf("uuid", cooperationLineage.toTypedArray())
 
         fluentJdbc
@@ -491,6 +505,7 @@ class MessageEventRepository(
         topic: String,
         eventLoopStrategy: EventLoopStrategy,
     ) {
+        logger.debug("Starting continuations: coroutine='{}', topic='{}'", coroutineName, topic)
         @Language("PostgreSQL")
         val sql =
             """

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/MessageRepository.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/MessageRepository.kt
@@ -5,6 +5,7 @@ import java.time.ZoneOffset
 import java.util.UUID
 import org.codejargon.fluentjdbc.api.FluentJdbc
 import org.postgresql.util.PGobject
+import org.slf4j.LoggerFactory
 
 /**
  * MessageRepository - Message persistence and retrieval operations
@@ -58,6 +59,10 @@ import org.postgresql.util.PGobject
  */
 class MessageRepository(private val fluentJdbc: FluentJdbc) {
 
+    companion object {
+        private val logger = LoggerFactory.getLogger(MessageRepository::class.java)
+    }
+
     /**
      * Retrieves a message by its unique identifier from the message table.
      *
@@ -93,6 +98,7 @@ class MessageRepository(private val fluentJdbc: FluentJdbc) {
                 )
             }
             .orElse(null)
+            .also { if (it == null) logger.debug("Message not found: id={}", messageId) }
 
     /**
      * Persists a new message to the message table and returns the complete message with generated
@@ -144,4 +150,5 @@ class MessageRepository(private val fluentJdbc: FluentJdbc) {
                             .atOffset(ZoneOffset.UTC),
                 )
             }
+            .also { logger.debug("Inserted message: id={}, topic='{}'", it.id, topic) }
 }

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
@@ -53,7 +53,7 @@ class PostgresMessageQueue(
     /** Fetches a message, given its [messageId]. */
     fun fetch(connection: Connection, messageId: UUID): Message? =
         messageRepository.fetchMessage(connection, messageId)?.also {
-            logger.info("Fetched message: id=${it.id}, topic=${it.topic}")
+            logger.debug("Fetched message: id=${it.id}, topic=${it.topic}")
         }
 
     /** Launches a message on the global scope, i.e., a top-level message. */
@@ -84,6 +84,7 @@ class PostgresMessageQueue(
      * from notifications.
      */
     fun subscribe(topic: String, saga: DistributedCoroutine): Subscription {
+        logger.debug("Subscribing saga '{}' to topic '{}'", saga.identifier, topic)
         val notifierHandle = topicNotifier.onMessage(topic) { eventLoop.tick(topic, saga) }
         topicsToCoroutines.add(topic to saga.identifier)
 

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/StubHandlerBlockingTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/StubHandlerBlockingTest.kt
@@ -1,0 +1,233 @@
+package io.github.gabrielshanahan.scoop.coroutine.structuredcooperation
+
+import io.github.gabrielshanahan.scoop.coroutine.NextStep
+import io.github.gabrielshanahan.scoop.coroutine.StructuredCooperationTest
+import io.github.gabrielshanahan.scoop.coroutine.builder.saga
+import io.github.gabrielshanahan.scoop.coroutine.ciSleep
+import io.github.gabrielshanahan.scoop.coroutine.eventloop.strategy.StandardEventLoopStrategy
+import io.github.gabrielshanahan.scoop.messaging.eventLoopStrategy
+import io.github.gabrielshanahan.scoop.transactional
+import io.quarkus.test.junit.QuarkusTest
+import java.time.OffsetDateTime
+import java.util.Collections
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Tests that a saga step properly blocks when a handler is registered in the topology but NOT
+ * subscribed to the event loop (a "stub handler").
+ *
+ * This reproduces the scenario from Topiari where a "HumanHandler" is declared in the topology for
+ * the "who is listening" check, but is never actually subscribed. The expectation is that the
+ * parent saga does NOT resume until someone externally writes SEEN + COMMITTED events for the stub
+ * handler.
+ */
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class StubHandlerBlockingTest : StructuredCooperationTest() {
+
+    private val stubTopic = "stub-topic"
+    private val stubHandlerName = "stub-handler"
+
+    /**
+     * Creates an event loop strategy that includes the stub handler in the topology, simulating
+     * what Topiari does with HumanHandler.
+     */
+    private fun strategyWithStubHandler() =
+        StandardEventLoopStrategy(OffsetDateTime.now()) {
+            handlerRegistry.listenersByTopic().toMutableMap().apply {
+                merge(stubTopic, listOf(stubHandlerName)) { a, b -> a + b }
+            }
+        }
+
+    private fun createRootSagaWithChildAndStub(
+        executionOrder: MutableList<String>,
+        loopCounter: AtomicInteger,
+        latch: CountDownLatch,
+    ) =
+        messageQueue.subscribe(
+            rootTopic,
+            saga("root-handler", strategyWithStubHandler()) {
+                step(
+                    "loop-step",
+                    invoke = { scope, message, iteration ->
+                        val count = loopCounter.incrementAndGet()
+                        executionOrder.add("loop-iter-$iteration")
+
+                        if (count == 1) {
+                            scope.launch(
+                                childTopic,
+                                jsonbHelper.toPGobject(mapOf("from" to "root")),
+                            )
+                            scope.launch(
+                                stubTopic,
+                                jsonbHelper.toPGobject(mapOf("task" to "wait-for-human")),
+                            )
+                            latch.countDown()
+                        }
+                        NextStep.Repeat
+                    },
+                )
+            },
+        )
+
+    @Test
+    fun `repeating step blocks when stub handler has not started`() {
+        val executionOrder = Collections.synchronizedList(mutableListOf<String>())
+        val loopCounter = AtomicInteger(0)
+        val latch = CountDownLatch(1)
+
+        val rootSubscription = createRootSagaWithChildAndStub(executionOrder, loopCounter, latch)
+
+        val childSubscription =
+            messageQueue.subscribe(
+                childTopic,
+                saga("child-handler", handlerRegistry.eventLoopStrategy()) {
+                    step { scope, message -> executionOrder.add("child-handler-done") }
+                },
+            )
+
+        try {
+            fluentJdbc.transactional { connection ->
+                messageQueue.launch(
+                    connection,
+                    rootTopic,
+                    jsonbHelper.toPGobject(mapOf("initial" to "true")),
+                )
+            }
+
+            Assertions.assertTrue(
+                latch.await(10, TimeUnit.SECONDS),
+                "First iteration did not complete",
+            )
+            ciSleep(2000)
+
+            Assertions.assertEquals(
+                listOf("loop-iter-0", "child-handler-done"),
+                executionOrder.filter { it != "child-handler-done" || executionOrder.contains(it) },
+            )
+
+            val loopIterations = executionOrder.filter { it.startsWith("loop-iter-") }
+            Assertions.assertEquals(
+                1,
+                loopIterations.size,
+                "Parent saga should execute only once when stub handler hasn't started. " +
+                    "Got: $executionOrder",
+            )
+        } finally {
+            rootSubscription.close()
+            childSubscription.close()
+        }
+    }
+
+    private fun externallyCompleteStubHandler() {
+        fluentJdbc.transactional { connection ->
+            val stubMessageData =
+                fluentJdbc
+                    .query()
+                    .select(
+                        """
+                        SELECT m.id as message_id, me.cooperation_lineage
+                        FROM message m
+                        JOIN message_event me ON me.message_id = m.id AND me.type = 'EMITTED'
+                        WHERE m.topic = :topic
+                        """
+                    )
+                    .namedParam("topic", stubTopic)
+                    .firstResult {
+                        it.getObject("message_id", UUID::class.java) to
+                            (it.getArray("cooperation_lineage").array as Array<*>)
+                                .map { it as java.util.UUID }
+                                .toTypedArray()
+                    }
+                    .get()
+
+            val (messageId, parentLineage) = stubMessageData
+            val childLineage = parentLineage + java.util.UUID.randomUUID()
+
+            for (type in listOf("SEEN", "COMMITTED")) {
+                fluentJdbc
+                    .query()
+                    .update(
+                        """
+                        INSERT INTO message_event (message_id, type, cooperation_lineage, coroutine_name, context)
+                        VALUES (:message_id, '${type}'::message_event_type, :lineage, :handler, '{}'::jsonb)
+                        """
+                    )
+                    .namedParam("message_id", messageId)
+                    .namedParam("lineage", childLineage)
+                    .namedParam("handler", stubHandlerName)
+                    .run()
+            }
+        }
+    }
+
+    @Test
+    fun `repeating step resumes after externally writing SEEN and COMMITTED for stub handler`() {
+        val executionOrder = Collections.synchronizedList(mutableListOf<String>())
+        val loopCounter = AtomicInteger(0)
+        val firstIterLatch = CountDownLatch(1)
+        val secondIterLatch = CountDownLatch(1)
+
+        val rootSubscription =
+            messageQueue.subscribe(
+                rootTopic,
+                saga("root-handler", strategyWithStubHandler()) {
+                    step(
+                        "loop-step",
+                        invoke = { scope, message, iteration ->
+                            val count = loopCounter.incrementAndGet()
+                            executionOrder.add("loop-iter-$iteration")
+
+                            if (count == 1) {
+                                scope.launch(
+                                    stubTopic,
+                                    jsonbHelper.toPGobject(mapOf("task" to "wait-for-human")),
+                                )
+                                firstIterLatch.countDown()
+                            } else if (count == 2) {
+                                secondIterLatch.countDown()
+                            }
+                            NextStep.Repeat
+                        },
+                    )
+                },
+            )
+
+        try {
+            fluentJdbc.transactional { connection ->
+                messageQueue.launch(
+                    connection,
+                    rootTopic,
+                    jsonbHelper.toPGobject(mapOf("initial" to "true")),
+                )
+            }
+
+            Assertions.assertTrue(
+                firstIterLatch.await(10, TimeUnit.SECONDS),
+                "First iteration did not complete",
+            )
+            ciSleep(500)
+            Assertions.assertEquals(1, loopCounter.get(), "Should be blocked after first iteration")
+
+            externallyCompleteStubHandler()
+
+            Assertions.assertTrue(
+                secondIterLatch.await(10, TimeUnit.SECONDS),
+                "Second iteration did not complete after externally writing SEEN+COMMITTED. " +
+                    "Events: ${executionOrder}",
+            )
+            Assertions.assertTrue(
+                loopCounter.get() >= 2,
+                "Parent should have executed at least twice after stub handler completed",
+            )
+        } finally {
+            rootSubscription.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Fix existing log levels**: Downgrade 6 `logger.info` calls to `logger.debug` in EventLoop and PostgresMessageQueue — these fire on every tick/message and are too noisy for production
- **Add strategic logging** to 6 previously unlogged files: Capabilities, BaseCooperationContinuation, RollbackPathContinuation, MessageEventRepository, MessageRepository, and Scoop factory
- **Fix pre-existing detekt violations** in StubHandlerBlockingTest (LongMethod)

### Log level philosophy
- **INFO**: Lifecycle events only (Scoop init, PgSubscriber connect)
- **DEBUG**: Execution flow tracing (step execution, message emission, continuation resumption)
- **WARN**: Significant decisions (saga giving up due to exceptions)
- **ERROR**: Actual failures (unchanged)

### Files changed
| File | Changes |
|------|---------|
| `EventLoop.kt` | 5x INFO→DEBUG |
| `PostgresMessageQueue.kt` | 1x INFO→DEBUG, add subscribe() DEBUG |
| `Scoop.kt` | Add logger + INFO on init |
| `Capabilities.kt` | Add logger + DEBUG/WARN to all methods |
| `CooperationContinuation.kt` | Add logger + DEBUG to resumeWith/resumeCoroutine/handleFailures/resume |
| `RollbackPathContinuation.kt` | Add logger + DEBUG for rollback plan |
| `MessageEventRepository.kt` | Add logger + DEBUG to insert/start methods |
| `MessageRepository.kt` | Add logger + DEBUG to insert/fetch |
| `StubHandlerBlockingTest.kt` | Extract helpers to fix detekt LongMethod |

## Test plan
- [x] `./gradlew build` passes (compile, ktfmt, detekt, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)