### PR TITLE
Fix polymorphic collection serialization in MappedElement

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Fixed
+
+- `CooperationContext` serialization now preserves `@JsonTypeInfo` discriminators for collection elements inside `MappedElement`s, fixing `InvalidTypeIdException` on round-trip of polymorphic collections
+
 ## v0.2.7 — 2026-04-05
 
 ### Changed

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/context/CooperationContextModule.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/context/CooperationContextModule.kt
@@ -12,8 +12,8 @@ import com.fasterxml.jackson.databind.SerializationConfig
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier
+import com.fasterxml.jackson.databind.ser.ResolvableSerializer
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 
 /**
@@ -140,14 +140,23 @@ class CooperationContextModule(private val objectMapper: ObjectMapper) :
 
                 is CooperationContext.Element -> {
                     gen.writeFieldName(value.key.serializedValue)
+                    // Ensure the original serializer for this type has been captured by our
+                    // BeanSerializerModifier side effect. findValueSerializer triggers the full
+                    // resolution chain (including modifySerializer), populating oldSerializers.
+                    if (value::class.java !in oldSerializers) {
+                        provider.findValueSerializer(value.javaClass)
+                    }
                     @Suppress("UNCHECKED_CAST")
                     val oldSerializer =
-                        (oldSerializers[value::class.java]
-                            ?: BeanSerializerFactory.instance.createSerializer(
-                                provider,
-                                provider.config.constructType(value.javaClass),
-                            ))
+                        oldSerializers.getValue(value::class.java)
                             as JsonSerializer<CooperationContext.Element>
+                    // The captured serializer was intercepted in modifySerializer *before* its
+                    // own resolve() pass ran. Without resolving, nested polymorphic collection
+                    // serializers are not wired with their AsPropertyTypeSerializer wrappers,
+                    // so @JsonTypeInfo discriminators get dropped for collection elements.
+                    if (oldSerializer is ResolvableSerializer) {
+                        oldSerializer.resolve(provider)
+                    }
                     oldSerializer.serialize(value, gen, provider)
                 }
 

--- a/scoop-core/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/context/CooperationContextPolymorphicCollectionTest.kt
+++ b/scoop-core/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/context/CooperationContextPolymorphicCollectionTest.kt
@@ -1,0 +1,57 @@
+package io.github.gabrielshanahan.scoop.coroutine.context
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CooperationContextPolymorphicCollectionTest {
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+    @JsonSubTypes(
+        JsonSubTypes.Type(Animal.Dog::class, name = "Dog"),
+        JsonSubTypes.Type(Animal.Cat::class, name = "Cat"),
+    )
+    sealed interface Animal {
+        data class Dog(val name: String) : Animal
+
+        data class Cat(val name: String, val livesLeft: Int) : Animal
+    }
+
+    data class Zoo(val animals: List<Animal>) : CooperationContext.MappedElement(ZooKey)
+
+    object ZooKey : CooperationContext.MappedKey<Zoo>()
+
+    private fun newMapper(): ObjectMapper =
+        ObjectMapper().registerKotlinModule().also {
+            it.registerModule(CooperationContextModule(it))
+        }
+
+    @Test
+    fun `polymorphic list inside MappedElement round-trips through CooperationContext`() {
+        val mapper = newMapper()
+        val original: CooperationContext =
+            Zoo(
+                animals =
+                    listOf(Animal.Dog(name = "Rex"), Animal.Cat(name = "Whiskers", livesLeft = 9))
+            )
+
+        val json = mapper.writeValueAsString(original)
+
+        // Sanity: discriminators must appear in the serialized form.
+        assert("\"type\":\"Dog\"" in json) {
+            "Expected 'type:\"Dog\"' discriminator in serialized JSON, got: $json"
+        }
+        assert("\"type\":\"Cat\"" in json) {
+            "Expected 'type:\"Cat\"' discriminator in serialized JSON, got: $json"
+        }
+
+        // Round-trip: deserialize and lazily access the element.
+        val restored = mapper.readValue(json, CooperationContext::class.java)
+        val zoo = restored[ZooKey]!!
+
+        assertEquals(original[ZooKey], zoo)
+    }
+}


### PR DESCRIPTION
## Summary
- `CooperationContextSerializer` was dropping `@JsonTypeInfo` discriminators for collection elements inside a `MappedElement`. Round-tripping a `MappedElement` with a `List<T>` of a sealed/polymorphic type failed on read with `InvalidTypeIdException: missing type id property 'type'`.
- Root cause: `BeanSerializerModifier.modifySerializer` captured the original bean serializer *before* its `resolve()` pass ran, so nested `CollectionSerializer`s were never wired with their `AsPropertyTypeSerializer` wrappers. Scalar polymorphic fields worked because property writers are resolved differently from collection element serializers.
- Fix: ensure the original serializer is captured via `provider.findValueSerializer` (which routes through the modifier side effect), then call `resolve(provider)` on it on first use before delegating. The `BeanSerializerFactory` direct-instantiation fallback is gone.

## Test plan
- [x] New test `CooperationContextPolymorphicCollectionTest` round-trips a `Zoo(animals: List<Animal>)` `MappedElement` where `Animal` is a `@JsonTypeInfo`/`@JsonSubTypes` sealed interface — fails before the fix, passes after.
- [x] Existing `CooperationContextModuleTest` still green.
- [x] Full `:scoop-core:test` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)