### PR TITLE
Add `instances` parameter to PostgresMessageQueue.subscribe

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Added
+
+- `instances` parameter on `PostgresMessageQueue.subscribe(...)` — spins up N independent workers for a saga within a single JVM, each with its own serialised tick loop and `DistributedCoroutineIdentifier` instance UUID. Workers compete via Postgres `FOR UPDATE SKIP LOCKED`, the same mechanism used for multi-service horizontal scaling. Defaults to 1 (unchanged behaviour).
+- `PostgresMessageQueue.requiredConnectionCount` property — minimum number of database connections Scoop may hold concurrently for its registered workers' event loops (equal to the sum of `instances` across all subscriptions, including the internal `sleep-handler`). Intended as an assertion target in integration tests: `assertTrue(poolMaxSize >= messageQueue.requiredConnectionCount)`.
+
+### Changed
+
+- `EventLoop.tickPeriodically` now returns a `PeriodicTick` handle (superseding the previous `AutoCloseable` return). `PeriodicTick.trigger()` queues an ad-hoc tick on the same single-thread executor that drives the schedule, so scheduled ticks and LISTEN/NOTIFY-driven wake-ups are serialised per saga identifier. Triggers that arrive while another tick is pending or running are coalesced — at most one tick is ever queued on the executor — so bursts of LISTEN/NOTIFY traffic cannot grow the queue unboundedly.
+
+### Fixed
+
+- LISTEN/NOTIFY callbacks for a subscribed saga no longer run on virtual threads concurrently with the scheduled tick — they are now funneled through the saga's single-thread tick executor. Previously a single worker could process multiple messages in parallel via two tick entry points, which defeated the "one `DistributedCoroutineIdentifier` = one serial worker" model; parallelism now comes exclusively from `instances > 1`.
+
 ## v0.2.8 — 2026-04-06
 
 ### Fixed

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
@@ -21,6 +21,8 @@ import java.time.Duration
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 import org.codejargon.fluentjdbc.api.FluentJdbc
@@ -166,16 +168,23 @@ class EventLoop(
      * [thundering herd problems](https://en.wikipedia.org/wiki/Thundering_herd_problem) when
      * multiple instances are running.
      *
+     * The returned [PeriodicTick] also exposes [trigger][PeriodicTick.trigger], which submits an
+     * ad-hoc tick onto the same single-thread executor. This is how push-based notifications (e.g.
+     * Postgres LISTEN/NOTIFY callbacks) wake the loop up without running concurrently with a
+     * scheduled tick — all ticks for a given [distributedCoroutine] are serialised through the
+     * executor, so a single saga identifier never runs overlapping continuations.
+     *
      * @param topic The message topic this saga handles
      * @param distributedCoroutine The saga definition to execute
      * @param runApproximatelyEvery How often to tick (with jitter applied)
-     * @return An [AutoCloseable] that can be used to stop the periodic ticking
+     * @return A [PeriodicTick] handle: [close][PeriodicTick.close] stops the ticker;
+     *   [trigger][PeriodicTick.trigger] queues an immediate tick on the same executor.
      */
     fun tickPeriodically(
         topic: String,
         distributedCoroutine: DistributedCoroutine,
         runApproximatelyEvery: Duration,
-    ): AutoCloseable {
+    ): PeriodicTick {
         val executor =
             Executors.newSingleThreadScheduledExecutor { r ->
                 Thread(r, "scoop-tick-${distributedCoroutine.identifier}").apply { isDaemon = true }
@@ -183,23 +192,63 @@ class EventLoop(
         val intervalMs = runApproximatelyEvery.toMillis()
         val jitterMs = (intervalMs * 0.02).toLong()
 
+        // One permit represents "there is at most one tick accounted for — running or queued."
+        // Both the scheduled path and [trigger] try-acquire *before* enqueuing and release once the
+        // tick finishes, so only one tick is ever pending on the executor at a time. Missed
+        // wake-ups are picked up by the next scheduled tick within `runApproximatelyEvery`, and the
+        // tick's inner `whileISaySo` loop opens a fresh transaction per iteration so it still sees
+        // messages committed while it was running.
+        val gate = Semaphore(1)
+
+        val runTick = Runnable {
+            try {
+                logger.debug(
+                    "Starting tick for topic $topic and coroutine ${distributedCoroutine.identifier}"
+                )
+                tick(topic, distributedCoroutine)
+            } catch (e: Exception) {
+                logger.error("Event loop for ${distributedCoroutine.identifier} failed", e)
+            } finally {
+                gate.release()
+            }
+        }
+
+        val scheduledTick = Runnable {
+            // Scheduled fires on a fixed cadence, but if a triggered tick is already pending or
+            // running this tick collapses to a no-op — the in-flight one will do the work.
+            if (!gate.tryAcquire()) return@Runnable
+            runTick.run()
+        }
+
         executor.scheduleWithFixedDelay(
-            {
-                try {
-                    logger.debug(
-                        "Starting tick for topic $topic and coroutine ${distributedCoroutine.identifier}"
-                    )
-                    tick(topic, distributedCoroutine)
-                } catch (e: Exception) {
-                    logger.error("Event loop for ${distributedCoroutine.identifier} failed", e)
-                }
-            },
+            scheduledTick,
             0,
             intervalMs + jitterMs,
             TimeUnit.MILLISECONDS,
         )
 
-        return AutoCloseable { executor.shutdown() }
+        return object : PeriodicTick {
+            override fun trigger() {
+                // Acquire first, enqueue second: if another tick is already pending or running,
+                // we drop this trigger entirely rather than piling up no-op runnables on the
+                // executor's queue. The permit is released by `runTick` or the catch branch below.
+                if (!gate.tryAcquire()) return
+                try {
+                    executor.execute(runTick)
+                } catch (e: RejectedExecutionException) {
+                    // The executor has been closed between acquire and enqueue; release and log.
+                    gate.release()
+                    logger.debug(
+                        "Ignoring trigger for already-closed tick executor of ${distributedCoroutine.identifier}",
+                        e,
+                    )
+                }
+            }
+
+            override fun close() {
+                executor.shutdown()
+            }
+        }
     }
 
     /**

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/PeriodicTick.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/PeriodicTick.kt
@@ -1,0 +1,37 @@
+package io.github.gabrielshanahan.scoop.coroutine
+
+/**
+ * Handle for a periodic tick loop started by
+ * [EventLoop.tickPeriodically][io.github.gabrielshanahan.scoop.coroutine.EventLoop.tickPeriodically].
+ *
+ * Backed by a single-thread executor, so every tick for a given saga identifier — whether produced
+ * by the periodic schedule or by an explicit [trigger] — is serialised. This is what guarantees
+ * that a single
+ * [DistributedCoroutineIdentifier][io.github.gabrielshanahan.scoop.coroutine.DistributedCoroutineIdentifier]
+ * never runs overlapping continuations: parallelism comes from registering more *instances* of the
+ * same saga (see
+ * [PostgresMessageQueue.subscribe][io.github.gabrielshanahan.scoop.messaging.PostgresMessageQueue.subscribe]),
+ * never from multiple entry points into one identifier.
+ */
+interface PeriodicTick : AutoCloseable {
+    /**
+     * Ask the loop to run a tick as soon as it's idle.
+     *
+     * Intended for push-based wake-ups (e.g. Postgres LISTEN/NOTIFY callbacks). The triggered tick
+     * is guaranteed to be executed sequentially with respect to scheduled ticks — there is at most
+     * one tick running per saga identifier at any given moment.
+     *
+     * ## Coalescing
+     *
+     * Triggers that arrive while another tick is already running or pending are silently dropped —
+     * they do not pile up on the executor's queue. This is safe: every tick drains all currently
+     * ready work before it returns (via the event loop's inner `whileISaySo` loop, which opens a
+     * fresh transaction per iteration), so the in-flight tick will observe any messages committed
+     * during its run. In the rare case a wake-up is dropped just as the previous tick is finishing,
+     * the next scheduled tick (within the configured interval) acts as a safety net — the same
+     * safety net that keeps Scoop correct without LISTEN/NOTIFY at all.
+     *
+     * Calls after [close] are silently ignored.
+     */
+    fun trigger()
+}

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
@@ -4,6 +4,7 @@ import io.github.gabrielshanahan.scoop.JsonbHelper
 import io.github.gabrielshanahan.scoop.coroutine.DistributedCoroutine
 import io.github.gabrielshanahan.scoop.coroutine.DistributedCoroutineIdentifier
 import io.github.gabrielshanahan.scoop.coroutine.EventLoop
+import io.github.gabrielshanahan.scoop.coroutine.PeriodicTick
 import io.github.gabrielshanahan.scoop.coroutine.builder.SLEEP_TOPIC
 import io.github.gabrielshanahan.scoop.coroutine.builder.SleepEventLoopStrategy
 import io.github.gabrielshanahan.scoop.coroutine.builder.saga
@@ -86,28 +87,116 @@ class PostgresMessageQueue(
      *    The [NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html) is done in a
      *    database trigger - search for `notify_message_insert`.
      *
-     * Returns a [Subscription], which can be used to cancel the periodic ticking, and unsubscribe
-     * from notifications.
+     * ## Multiple Instances
+     *
+     * [instances] controls how many independent workers are spun up for this saga within this JVM.
+     * Each worker gets its own serialised tick loop and its own
+     * [DistributedCoroutineIdentifier.instance][io.github.gabrielshanahan.scoop.coroutine.DistributedCoroutineIdentifier.instance]
+     * UUID under a shared name, and workers compete for pending saga runs using Postgres `FOR
+     * UPDATE SKIP LOCKED` — exactly the same mechanism that lets multiple *service* instances scale
+     * horizontally.
+     *
+     * Parallelism in Scoop comes exclusively from adding instances: a single worker never runs
+     * overlapping continuations, because scheduled ticks and LISTEN/NOTIFY-driven ticks are
+     * funneled through the same single-thread executor (see
+     * [PeriodicTick][io.github.gabrielshanahan.scoop.coroutine.PeriodicTick]). Want N-way
+     * in-process throughput? Set `instances = N`.
+     *
+     * The default ([instances] = 1) preserves the previous behaviour of one worker per
+     * subscription.
+     *
+     * Returns a [Subscription], which can be used to cancel the periodic ticking of all instances
+     * and unsubscribe from notifications.
+     *
+     * @param topic The message topic this saga handles
+     * @param saga The saga definition (its [steps][DistributedCoroutine.steps] and
+     *   [event loop strategy][DistributedCoroutine.eventLoopStrategy] are shared across all
+     *   instances; they must be safe to invoke concurrently)
+     * @param instances How many independent workers to spin up (must be `>= 1`, default 1)
      */
-    fun subscribe(topic: String, saga: DistributedCoroutine): Subscription {
-        logger.debug("Subscribing saga '{}' to topic '{}'", saga.identifier, topic)
-        val notifierHandle = topicNotifier.onMessage(topic) { eventLoop.tick(topic, saga) }
-        topicsToCoroutines.add(topic to saga.identifier)
+    fun subscribe(topic: String, saga: DistributedCoroutine, instances: Int = 1): Subscription {
+        require(instances >= 1) { "instances must be >= 1, was $instances" }
 
-        val subscription = eventLoop.tickPeriodically(topic, saga, tickInterval)
+        logger.debug(
+            "Subscribing saga '{}' to topic '{}' with {} instance(s)",
+            saga.identifier.name,
+            topic,
+            instances,
+        )
+
+        // First worker reuses the identifier the caller built, so `instances = 1` is byte-for-byte
+        // identical to the pre-fan-out behaviour. Additional workers get fresh UUIDs under the
+        // same saga name and therefore show up as distinct instances in logs, stack traces, and
+        // message_event rows — matching the semantics of running N service instances.
+        val workerSagas = buildList {
+            add(saga)
+            repeat(instances - 1) {
+                add(
+                    DistributedCoroutine(
+                        identifier = DistributedCoroutineIdentifier(saga.identifier.name),
+                        steps = saga.steps,
+                        eventLoopStrategy = saga.eventLoopStrategy,
+                    )
+                )
+            }
+        }
+
+        val workerHandles =
+            workerSagas.map { workerSaga ->
+                val periodicTick = eventLoop.tickPeriodically(topic, workerSaga, tickInterval)
+                // Route the NOTIFY callback through the worker's own single-thread executor so
+                // that push-driven ticks never run concurrently with the scheduled tick — each
+                // worker stays strictly serial, and parallelism comes only from `instances`.
+                val notifierHandle = topicNotifier.onMessage(topic) { periodicTick.trigger() }
+                topicsToCoroutines.add(topic to workerSaga.identifier)
+                WorkerHandle(workerSaga.identifier, notifierHandle, periodicTick)
+            }
 
         return Subscription {
-            topicsToCoroutines.remove(topic to saga.identifier)
-            subscription.close()
-            notifierHandle.close()
+            workerHandles.forEach { handle ->
+                topicsToCoroutines.remove(topic to handle.identifier)
+                handle.periodicTick.close()
+                handle.notifierHandle.close()
+            }
         }
     }
+
+    private data class WorkerHandle(
+        val identifier: DistributedCoroutineIdentifier,
+        val notifierHandle: AutoCloseable,
+        val periodicTick: PeriodicTick,
+    )
 
     override fun listenersByTopic(): Map<String, List<String>> =
         topicsToCoroutines
             .map { (topic, identifier) -> topic to identifier.name }
             .distinct()
             .groupBy({ it.first }, { it.second })
+
+    /**
+     * Minimum number of database connections Scoop may hold concurrently for its registered
+     * workers' event loops.
+     *
+     * Each subscribed worker (each saga identifier produced by [subscribe]) holds at most one
+     * connection at a time — it runs one [tick][EventLoop.tick] transaction at a time, and step
+     * invocations within a tick run sequentially. The total concurrent demand for Scoop's own
+     * event-loop work is therefore equal to the total number of subscribed worker instances across
+     * all topics (which includes the internal `sleep-handler` subscription).
+     *
+     * Consumers can use this in an integration test to assert that their configured connection pool
+     * is large enough to let every worker make progress without blocking for a connection:
+     * ```kotlin
+     * @Test
+     * fun `jdbc pool is sized for registered workers`() {
+     *     assertTrue(configuredPoolMaxSize >= messageQueue.requiredConnectionCount)
+     * }
+     * ```
+     *
+     * This count covers Scoop's tick work only. If your step bodies acquire additional connections
+     * (for side-effect queries outside the step's transaction), add that to your sizing budget.
+     */
+    val requiredConnectionCount: Int
+        get() = topicsToCoroutines.size
 
     companion object {
         private val logger = LoggerFactory.getLogger(PostgresMessageQueue::class.java)

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueueTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueueTest.kt
@@ -6,11 +6,13 @@ import io.github.gabrielshanahan.scoop.coroutine.builder.saga
 import io.github.gabrielshanahan.scoop.coroutine.ciSleep
 import io.github.gabrielshanahan.scoop.transactional
 import io.quarkus.test.junit.QuarkusTest
+import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -148,5 +150,99 @@ class PostgresMessageQueueTest : StructuredCooperationTest() {
                 )
             }
         ciSleep(200)
+    }
+
+    @Test
+    fun `subscribe with multiple instances fans work out across distinct instance UUIDs`() {
+        val instanceCount = 3
+        // One message per worker. Each worker is single-threaded (scheduled and NOTIFY ticks are
+        // funneled through the same executor) and blocks in `await` inside its step, holding the
+        // row lock via SKIP LOCKED. That forces every message to be picked up by a *different*
+        // worker, so exactly `instanceCount` distinct instance UUIDs must participate.
+        val latch = CountDownLatch(instanceCount)
+        val seenInstances = Collections.synchronizedSet(mutableSetOf<String>())
+        val seenNames = Collections.synchronizedSet(mutableSetOf<String>())
+
+        messageQueue
+            .subscribe(
+                testTopic,
+                saga(testHandler, handlerRegistry.eventLoopStrategy()) {
+                    step { scope, _ ->
+                        val identifier =
+                            scope.continuation.continuationIdentifier.distributedCoroutineIdentifier
+                        seenInstances.add(identifier.instance)
+                        seenNames.add(identifier.name)
+                        latch.countDown()
+                        check(latch.await(10, TimeUnit.SECONDS)) {
+                            "Timed out waiting for all $instanceCount workers to enter the step"
+                        }
+                    }
+                },
+                instances = instanceCount,
+            )
+            .use {
+                for (i in 1..instanceCount) {
+                    val payload = jsonbHelper.toPGobject(mapOf("text" to "Message $i"))
+                    fluentJdbc.transactional { connection ->
+                        messageQueue.launch(connection, testTopic, payload)
+                    }
+                }
+
+                assertTrue(
+                    latch.await(10, TimeUnit.SECONDS),
+                    "All $instanceCount messages should be processed concurrently",
+                )
+
+                assertEquals(
+                    instanceCount,
+                    seenInstances.size,
+                    "Expected exactly $instanceCount distinct instance UUIDs, saw: $seenInstances",
+                )
+                assertEquals(
+                    setOf(testHandler),
+                    seenNames,
+                    "All instances should share the saga name",
+                )
+            }
+        ciSleep(200)
+    }
+
+    @Test
+    fun `subscribe rejects instances less than one`() {
+        val saga = saga(testHandler, handlerRegistry.eventLoopStrategy()) { step { _, _ -> } }
+
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                messageQueue.subscribe(testTopic, saga, instances = 0)
+            }
+        assertTrue(
+            ex.message!!.contains("instances must be >= 1"),
+            "Unexpected message: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `requiredConnectionCount reflects registered worker instances`() {
+        val baseline = messageQueue.requiredConnectionCount
+
+        val subscription =
+            messageQueue.subscribe(
+                testTopic,
+                saga(testHandler, handlerRegistry.eventLoopStrategy()) { step { _, _ -> } },
+                instances = 3,
+            )
+        subscription.use {
+            assertEquals(
+                baseline + 3,
+                messageQueue.requiredConnectionCount,
+                "Subscribing with instances = 3 should add 3 workers to the connection budget",
+            )
+        }
+
+        assertEquals(
+            baseline,
+            messageQueue.requiredConnectionCount,
+            "Closing the subscription should release all three workers from the connection budget",
+        )
     }
 }


### PR DESCRIPTION
## Summary

- Adds `instances: Int = 1` on `PostgresMessageQueue.subscribe(topic, saga, ...)`, letting callers fan a saga out to N independent in-process workers. Each worker has its own `DistributedCoroutineIdentifier(name, <fresh UUID>)`. Workers compete for rows via `FOR UPDATE SKIP LOCKED` — no new coordination primitives.
- Fixes a latent concurrency hole: previously, the LISTEN/NOTIFY callback ran on a virtual thread *concurrently* with the scheduled tick for the same worker, so a single `DistributedCoroutineIdentifier` could process multiple messages in parallel. That defeated "one identifier = one serial worker" and made the new `instances` knob misleading.
- `EventLoop.tickPeriodically` now returns a `PeriodicTick` handle (superseding `AutoCloseable`). `PeriodicTick.trigger()` submits an ad-hoc tick onto the same single-thread executor that drives the schedule, so scheduled ticks and NOTIFY wake-ups for a given worker are serialised through one FIFO.
- **Coalescing gate.** A `Semaphore(1)` ensures at most one tick is pending or running per worker. Extra triggers (e.g. burst NOTIFY traffic) are dropped rather than piling up on the executor's queue. Safe because each tick's inner `whileISaySo` opens a fresh transaction per iteration — an in-flight tick observes messages committed during its run; the scheduled tick is the safety net for wake-ups that arrive exactly as a tick is finishing.
- **Connection-sizing helper.** New `PostgresMessageQueue.requiredConnectionCount` property returns the sum of all subscribed worker instances. Intended for integration tests: `assertTrue(configuredPoolMaxSize >= messageQueue.requiredConnectionCount)` — catches config drift when someone raises `instances` without also bumping the JDBC pool.
- **Parallelism in Scoop now comes exclusively from `instances > 1`.** Default `instances = 1` is byte-for-byte compatible with the previous behaviour.

## Test plan

- [x] `:scoop-core:test` — 63/63 pass
- [x] `:scoop-quarkus:test` — 119/119 pass (+3 new)
- [x] New: `subscribe with multiple instances fans work out across distinct instance UUIDs` — `instances = 3` with 3 messages, each step records its UUID and blocks on a shared latch. Under the serialised model each worker holds its row lock while blocked, so **exactly 3 distinct UUIDs must participate**.
- [x] New: `subscribe rejects instances less than one` — `instances = 0` throws `IllegalArgumentException`.
- [x] New: `requiredConnectionCount reflects registered worker instances` — subscribes with `instances = 3`, asserts the property jumps by 3, then asserts it returns to baseline after `subscription.close()`.
- [x] `ktfmtCheck` clean on both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)