### PR TITLE
fix: drain ticks at shutdown; pause-able ticks for test cleanup

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Changed
+
+- `PostgresMessageQueue` now implements `AutoCloseable`. The Quarkus `ScoopProducer` registers a CDI `@Disposes` method that calls `messageQueue.close()` on bean destroy, which stops the internal `sleep-handler` subscription before the surrounding `DataSource` tears down.
+
+### Fixed
+
+- `Subscription.close()` now blocks until in-flight ticks have actually drained: `PeriodicTick.close()` calls `executor.awaitTermination(...)` after `shutdown()`, with a `shutdownNow()` fallback if the soft timeout expires. Previously close() returned immediately and ticks kept running on their daemon thread; combined with Quarkus tearing down ArC and Agroal in parallel with `@PreDestroy`, this produced unbounded `Error in when ticking` / `pool is closed` / `ArC container not initialized` log spam during application shutdown. Tick-failure logs are also demoted to DEBUG once the queue is shutting down, silencing the racy log lines that fire during the @PreDestroy / Agroal teardown window.
+
 ## v0.2.9 — 2026-04-23
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Added
+
+- `PostgresMessageQueue.pauseTicks()` / `resumeTicks()` — temporarily pauses the scheduled-tick path on every active subscription (including the internal `sleep-handler`). Intended for test fixtures that need to TRUNCATE Scoop's tables without racing live ticks; without it, TRUNCATE's `AccessExclusiveLock` deadlocks with the tick's `AccessShareLock` from `SELECT FOR UPDATE SKIP LOCKED`.
+
 ### Changed
 
 - `PostgresMessageQueue` now implements `AutoCloseable`. The Quarkus `ScoopProducer` registers a CDI `@Disposes` method that calls `messageQueue.close()` on bean destroy, which stops the internal `sleep-handler` subscription before the surrounding `DataSource` tears down.

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -64,7 +64,7 @@
     <ID>MemberNameEqualsClassName:PendingCoroutineRunSqlTest.kt$PendingCoroutineRunSqlTest.FinalSelect$val finalSelect = finalSelect(registryStrategy)</ID>
     <ID>MemberNameEqualsClassName:PendingCoroutineRunSqlTest.kt$PendingCoroutineRunSqlTest.SeenForProcessing$val seenForProcessing = seenForProcessing(registryStrategy)</ID>
     <ID>ReturnCount:CooperationContextMap.kt$CooperationContextMap$@Suppress("UNCHECKED_CAST") override fun &lt;E : CooperationContext.Element&gt; get(key: CooperationContext.Key&lt;E&gt;): E?</ID>
-    <ID>ThrowsCount:EventLoop.kt$EventLoop$fun tick(topic: String, distributedCoroutine: DistributedCoroutine)</ID>
+    <ID>ThrowsCount:EventLoop.kt$EventLoop$fun tick( topic: String, distributedCoroutine: DistributedCoroutine, isShuttingDown: () -&gt; Boolean = { false }, )</ID>
     <ID>ThrowsCount:RollbackPathTest.kt$RollbackPathTest$@Test fun `a handler failing in its second step should emit ROLLBACK_EMITTEDs for messages emitted in the first step, and then roll it back`()</ID>
     <ID>ThrowsCount:RollbackPathTest.kt$RollbackPathTest$@Test fun `failed rollbacks are well behaved n-deep`()</ID>
     <ID>ThrowsCount:RollbackPathTest.kt$RollbackPathTest$@Test fun `when a child fails, rollbacks happen in reverse order`()</ID>

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
@@ -30,6 +30,21 @@ import org.postgresql.jdbc.PgConnection
 import org.slf4j.LoggerFactory
 
 /**
+ * Maximum time [PeriodicTick.close] will block on [java.util.concurrent.ExecutorService.awaitTermination]
+ * waiting for an in-flight tick to finish gracefully. Bounded so a stuck tick (e.g. a hung DB
+ * query) cannot deadlock application shutdown indefinitely.
+ */
+private const val SHUTDOWN_TIMEOUT_SECONDS = 10L
+
+/**
+ * Additional time [PeriodicTick.close] will wait after issuing an interrupt
+ * ([java.util.concurrent.ExecutorService.shutdownNow]) when the soft shutdown timed out. Short on
+ * purpose: the tick should respond to the interrupt by throwing out of its DB call within a
+ * handful of milliseconds; if it does not, the surrounding application is in trouble regardless.
+ */
+private const val SHUTDOWN_INTERRUPT_TIMEOUT_SECONDS = 2L
+
+/**
  * The core execution engine that drives structured cooperation by resuming suspended sagas.
  *
  * The [EventLoop] is the heart of Scoop's execution model. It implements the "event loop" pattern
@@ -108,7 +123,11 @@ class EventLoop(
      * @param topic The message topic this saga is subscribed to
      * @param distributedCoroutine The saga definition to execute
      */
-    fun tick(topic: String, distributedCoroutine: DistributedCoroutine) {
+    fun tick(
+        topic: String,
+        distributedCoroutine: DistributedCoroutine,
+        isShuttingDown: () -> Boolean = { false },
+    ) {
         try {
             fluentJdbc.transactional { connection ->
                 try {
@@ -156,7 +175,16 @@ class EventLoop(
                 }
             }
         } catch (e: Exception) {
-            logger.error("Error in when ticking", e)
+            // During application shutdown, the surrounding [DataSource] and CDI container can be
+            // torn down concurrently with our @PreDestroy chain — see
+            // [PostgresMessageQueue.close]. Any tick that races teardown will throw at
+            // connection acquisition time. That's expected, not actionable: surfacing it as an
+            // ERROR floods the log. Demote to debug.
+            if (isShuttingDown()) {
+                logger.debug("Tick failure during shutdown for ${distributedCoroutine.identifier}", e)
+            } else {
+                logger.error("Error in when ticking", e)
+            }
         }
     }
 
@@ -184,6 +212,7 @@ class EventLoop(
         topic: String,
         distributedCoroutine: DistributedCoroutine,
         runApproximatelyEvery: Duration,
+        isShuttingDown: () -> Boolean = { false },
     ): PeriodicTick {
         val executor =
             Executors.newSingleThreadScheduledExecutor { r ->
@@ -205,7 +234,7 @@ class EventLoop(
                 logger.debug(
                     "Starting tick for topic $topic and coroutine ${distributedCoroutine.identifier}"
                 )
-                tick(topic, distributedCoroutine)
+                tick(topic, distributedCoroutine, isShuttingDown)
             } catch (e: Exception) {
                 logger.error("Event loop for ${distributedCoroutine.identifier} failed", e)
             } finally {
@@ -214,6 +243,11 @@ class EventLoop(
         }
 
         val scheduledTick = Runnable {
+            // Skip new ticks once the surrounding queue has signalled shutdown — the in-flight
+            // tick on this executor (if any) is still allowed to finish, but no fresh tick will
+            // start. Combined with `isShuttingDown` being checked inside [tick]'s catch, this
+            // prevents the noisy "Error in when ticking" log spam during Quarkus / Agroal teardown.
+            if (isShuttingDown()) return@Runnable
             // Scheduled fires on a fixed cadence, but if a triggered tick is already pending or
             // running this tick collapses to a no-op — the in-flight one will do the work.
             if (!gate.tryAcquire()) return@Runnable
@@ -246,7 +280,31 @@ class EventLoop(
             }
 
             override fun close() {
+                // Stop accepting new submissions and cancel future periodic firings, then block
+                // until any in-flight tick has finished. Without the await, close() returns while
+                // the executor's worker thread is mid-`tick(...)`, and that tick keeps running on
+                // its own thread after the caller has moved on. In a Quarkus shutdown scenario the
+                // caller's @PreDestroy returns, Quarkus tears down ArC and Agroal in parallel, and
+                // the still-running tick fails to acquire a connection — producing the
+                // "Error in when ticking" / "pool is closed" / "ArC container not initialized"
+                // log spam that motivated this fix.
+                //
+                // If a tick is genuinely stuck past the soft timeout (e.g. a long-running
+                // rollback transaction), fall back to interrupt + brief secondary await so
+                // close() never returns while a tick thread is still alive holding row locks
+                // (which would deadlock the next test's @BeforeEach TRUNCATE).
                 executor.shutdown()
+                if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    logger.warn(
+                        "Tick executor for ${distributedCoroutine.identifier} did not terminate within $SHUTDOWN_TIMEOUT_SECONDS s; interrupting"
+                    )
+                    executor.shutdownNow()
+                    if (!executor.awaitTermination(SHUTDOWN_INTERRUPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        logger.warn(
+                            "Tick executor for ${distributedCoroutine.identifier} did not terminate even after shutdownNow; thread may still be running"
+                        )
+                    }
+                }
             }
         }
     }

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
@@ -30,17 +30,18 @@ import org.postgresql.jdbc.PgConnection
 import org.slf4j.LoggerFactory
 
 /**
- * Maximum time [PeriodicTick.close] will block on [java.util.concurrent.ExecutorService.awaitTermination]
- * waiting for an in-flight tick to finish gracefully. Bounded so a stuck tick (e.g. a hung DB
- * query) cannot deadlock application shutdown indefinitely.
+ * Maximum time [PeriodicTick.close] will block on
+ * [java.util.concurrent.ExecutorService.awaitTermination] waiting for an in-flight tick to finish
+ * gracefully. Bounded so a stuck tick (e.g. a hung DB query) cannot deadlock application shutdown
+ * indefinitely.
  */
 private const val SHUTDOWN_TIMEOUT_SECONDS = 10L
 
 /**
  * Additional time [PeriodicTick.close] will wait after issuing an interrupt
  * ([java.util.concurrent.ExecutorService.shutdownNow]) when the soft shutdown timed out. Short on
- * purpose: the tick should respond to the interrupt by throwing out of its DB call within a
- * handful of milliseconds; if it does not, the surrounding application is in trouble regardless.
+ * purpose: the tick should respond to the interrupt by throwing out of its DB call within a handful
+ * of milliseconds; if it does not, the surrounding application is in trouble regardless.
  */
 private const val SHUTDOWN_INTERRUPT_TIMEOUT_SECONDS = 2L
 
@@ -181,7 +182,10 @@ class EventLoop(
             // connection acquisition time. That's expected, not actionable: surfacing it as an
             // ERROR floods the log. Demote to debug.
             if (isShuttingDown()) {
-                logger.debug("Tick failure during shutdown for ${distributedCoroutine.identifier}", e)
+                logger.debug(
+                    "Tick failure during shutdown for ${distributedCoroutine.identifier}",
+                    e,
+                )
             } else {
                 logger.error("Error in when ticking", e)
             }
@@ -299,7 +303,12 @@ class EventLoop(
                         "Tick executor for ${distributedCoroutine.identifier} did not terminate within $SHUTDOWN_TIMEOUT_SECONDS s; interrupting"
                     )
                     executor.shutdownNow()
-                    if (!executor.awaitTermination(SHUTDOWN_INTERRUPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    if (
+                        !executor.awaitTermination(
+                            SHUTDOWN_INTERRUPT_TIMEOUT_SECONDS,
+                            TimeUnit.SECONDS,
+                        )
+                    ) {
                         logger.warn(
                             "Tick executor for ${distributedCoroutine.identifier} did not terminate even after shutdownNow; thread may still be running"
                         )

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
@@ -16,6 +16,7 @@ import java.time.Duration
 import java.time.OffsetDateTime
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import org.postgresql.util.PGobject
 import org.slf4j.LoggerFactory
 
@@ -42,20 +43,37 @@ class PostgresMessageQueue(
     private val messageRepository: MessageRepository,
     private val eventLoop: EventLoop,
     private val tickInterval: Duration = DEFAULT_TICK_INTERVAL,
-) : HandlerRegistry {
+) : HandlerRegistry, AutoCloseable {
 
     private val topicsToCoroutines =
         ConcurrentHashMap.newKeySet<Pair<String, DistributedCoroutineIdentifier>>()
 
-    /** This is explained in [SLEEP_TOPIC]. */
-    init {
+    /**
+     * Set to true once [close] is invoked. All [PeriodicTick]s created by [subscribe] read this
+     * via the `isShuttingDown` parameter to [EventLoop.tickPeriodically]: scheduled ticks become
+     * no-ops, and any in-flight tick that throws (e.g. because Agroal has already been closed by
+     * Quarkus) demotes the failure log from ERROR to DEBUG. This is what eliminates the
+     * "Error in when ticking" / "pool is closed" / "ArC container not initialized" log spam
+     * during application shutdown — the @PreDestroy ordering between Scoop and Agroal is racy in
+     * practice, so the noise has to be suppressed at the source.
+     */
+    private val shuttingDown = AtomicBoolean(false)
+
+    /**
+     * Internal sleep-handler subscription used by [SLEEP_TOPIC]. Held so [close] can stop it
+     * before the surrounding application's [DataSource][javax.sql.DataSource] tears down — without
+     * this, the sleep-handler ticker keeps polling Postgres after user-side subscriptions are
+     * gone and produces the same "Error in when ticking" log spam at shutdown that motivated the
+     * blocking [PeriodicTick.close][io.github.gabrielshanahan.scoop.coroutine.PeriodicTick.close]
+     * contract.
+     */
+    private val internalSleepSubscription: Subscription =
         subscribe(
             SLEEP_TOPIC,
             saga("sleep-handler", SleepEventLoopStrategy(OffsetDateTime.now())) {
                 step("sleep") { _, _ -> }
             },
         )
-    }
 
     /** Fetches a message, given its [messageId]. */
     fun fetch(connection: Connection, messageId: UUID): Message? =
@@ -143,7 +161,13 @@ class PostgresMessageQueue(
 
         val workerHandles =
             workerSagas.map { workerSaga ->
-                val periodicTick = eventLoop.tickPeriodically(topic, workerSaga, tickInterval)
+                val periodicTick =
+                    eventLoop.tickPeriodically(
+                        topic,
+                        workerSaga,
+                        tickInterval,
+                        isShuttingDown = { shuttingDown.get() },
+                    )
                 // Route the NOTIFY callback through the worker's own single-thread executor so
                 // that push-driven ticks never run concurrently with the scheduled tick — each
                 // worker stays strictly serial, and parallelism comes only from `instances`.
@@ -197,6 +221,26 @@ class PostgresMessageQueue(
      */
     val requiredConnectionCount: Int
         get() = topicsToCoroutines.size
+
+    /**
+     * Stops the internal sleep-handler subscription. Application-owned subscriptions returned by
+     * [subscribe] are owned by the caller and must be closed by the caller.
+     *
+     * In a Quarkus/CDI deployment this is wired through a CDI disposer (see scoop-quarkus's
+     * `ScoopProducer`) so that the sleep-handler stops ticking before Quarkus tears down the
+     * surrounding [DataSource][javax.sql.DataSource]. Without it, the sleep-handler's periodic
+     * tick keeps firing after user-side subscriptions are closed, hits a half-torn-down Agroal
+     * pool, and produces the `Error in when ticking` log spam this fix is designed to eliminate.
+     */
+    override fun close() {
+        // Set the shutdown flag *before* closing anything: every [PeriodicTick] created via
+        // [subscribe] (the internal sleep-handler plus all user-side subscriptions) reads this
+        // through the `isShuttingDown` callback wired into [EventLoop.tickPeriodically], so once
+        // it flips no new tick will start and any in-flight tick that throws will log at debug.
+        // This silences the log spam during the racy @PreDestroy / Agroal teardown window.
+        shuttingDown.set(true)
+        internalSleepSubscription.close()
+    }
 
     companion object {
         private val logger = LoggerFactory.getLogger(PostgresMessageQueue::class.java)

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
@@ -52,30 +52,29 @@ class PostgresMessageQueue(
      * Set to true once [close] is invoked. All [PeriodicTick]s created by [subscribe] read this
      * (along with [ticksPaused], see below) via the `isShuttingDown` parameter to
      * [EventLoop.tickPeriodically]: scheduled ticks become no-ops, and any in-flight tick that
-     * throws (e.g. because Agroal has already been closed by Quarkus) demotes the failure log
-     * from ERROR to DEBUG. This is what eliminates the "Error in when ticking" / "pool is closed"
-     * / "ArC container not initialized" log spam during application shutdown — the @PreDestroy
-     * ordering between Scoop and Agroal is racy in practice, so the noise has to be suppressed at
-     * the source.
+     * throws (e.g. because Agroal has already been closed by Quarkus) demotes the failure log from
+     * ERROR to DEBUG. This is what eliminates the "Error in when ticking" / "pool is closed" / "ArC
+     * container not initialized" log spam during application shutdown — the @PreDestroy ordering
+     * between Scoop and Agroal is racy in practice, so the noise has to be suppressed at the
+     * source.
      */
     private val shuttingDown = AtomicBoolean(false)
 
     /**
      * Set/cleared by [pauseTicks] / [resumeTicks]. Same effect on the tick path as [shuttingDown]
-     * (skip new ticks; demote failure logs), but reversible — intended for test fixtures that
-     * need to TRUNCATE Scoop's tables without racing the always-on internal sleep-handler tick.
-     * Without this pause, TRUNCATE's AccessExclusiveLock deadlocks with the tick's AccessShareLock
-     * during `@BeforeEach` cleanup.
+     * (skip new ticks; demote failure logs), but reversible — intended for test fixtures that need
+     * to TRUNCATE Scoop's tables without racing the always-on internal sleep-handler tick. Without
+     * this pause, TRUNCATE's AccessExclusiveLock deadlocks with the tick's AccessShareLock during
+     * `@BeforeEach` cleanup.
      */
     private val ticksPaused = AtomicBoolean(false)
 
     /**
-     * Internal sleep-handler subscription used by [SLEEP_TOPIC]. Held so [close] can stop it
-     * before the surrounding application's [DataSource][javax.sql.DataSource] tears down — without
-     * this, the sleep-handler ticker keeps polling Postgres after user-side subscriptions are
-     * gone and produces the same "Error in when ticking" log spam at shutdown that motivated the
-     * blocking [PeriodicTick.close][io.github.gabrielshanahan.scoop.coroutine.PeriodicTick.close]
-     * contract.
+     * Internal sleep-handler subscription used by [SLEEP_TOPIC]. Held so [close] can stop it before
+     * the surrounding application's [DataSource][javax.sql.DataSource] tears down — without this,
+     * the sleep-handler ticker keeps polling Postgres after user-side subscriptions are gone and
+     * produces the same "Error in when ticking" log spam at shutdown that motivated the blocking
+     * [PeriodicTick.close][io.github.gabrielshanahan.scoop.coroutine.PeriodicTick.close] contract.
      */
     private val internalSleepSubscription: Subscription =
         subscribe(
@@ -256,9 +255,9 @@ class PostgresMessageQueue(
      *
      * In a Quarkus/CDI deployment this is wired through a CDI disposer (see scoop-quarkus's
      * `ScoopProducer`) so that the sleep-handler stops ticking before Quarkus tears down the
-     * surrounding [DataSource][javax.sql.DataSource]. Without it, the sleep-handler's periodic
-     * tick keeps firing after user-side subscriptions are closed, hits a half-torn-down Agroal
-     * pool, and produces the `Error in when ticking` log spam this fix is designed to eliminate.
+     * surrounding [DataSource][javax.sql.DataSource]. Without it, the sleep-handler's periodic tick
+     * keeps firing after user-side subscriptions are closed, hits a half-torn-down Agroal pool, and
+     * produces the `Error in when ticking` log spam this fix is designed to eliminate.
      */
     override fun close() {
         // Set the shutdown flag *before* closing anything: every [PeriodicTick] created via

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
@@ -50,14 +50,24 @@ class PostgresMessageQueue(
 
     /**
      * Set to true once [close] is invoked. All [PeriodicTick]s created by [subscribe] read this
-     * via the `isShuttingDown` parameter to [EventLoop.tickPeriodically]: scheduled ticks become
-     * no-ops, and any in-flight tick that throws (e.g. because Agroal has already been closed by
-     * Quarkus) demotes the failure log from ERROR to DEBUG. This is what eliminates the
-     * "Error in when ticking" / "pool is closed" / "ArC container not initialized" log spam
-     * during application shutdown — the @PreDestroy ordering between Scoop and Agroal is racy in
-     * practice, so the noise has to be suppressed at the source.
+     * (along with [ticksPaused], see below) via the `isShuttingDown` parameter to
+     * [EventLoop.tickPeriodically]: scheduled ticks become no-ops, and any in-flight tick that
+     * throws (e.g. because Agroal has already been closed by Quarkus) demotes the failure log
+     * from ERROR to DEBUG. This is what eliminates the "Error in when ticking" / "pool is closed"
+     * / "ArC container not initialized" log spam during application shutdown — the @PreDestroy
+     * ordering between Scoop and Agroal is racy in practice, so the noise has to be suppressed at
+     * the source.
      */
     private val shuttingDown = AtomicBoolean(false)
+
+    /**
+     * Set/cleared by [pauseTicks] / [resumeTicks]. Same effect on the tick path as [shuttingDown]
+     * (skip new ticks; demote failure logs), but reversible — intended for test fixtures that
+     * need to TRUNCATE Scoop's tables without racing the always-on internal sleep-handler tick.
+     * Without this pause, TRUNCATE's AccessExclusiveLock deadlocks with the tick's AccessShareLock
+     * during `@BeforeEach` cleanup.
+     */
+    private val ticksPaused = AtomicBoolean(false)
 
     /**
      * Internal sleep-handler subscription used by [SLEEP_TOPIC]. Held so [close] can stop it
@@ -166,7 +176,7 @@ class PostgresMessageQueue(
                         topic,
                         workerSaga,
                         tickInterval,
-                        isShuttingDown = { shuttingDown.get() },
+                        isShuttingDown = { shuttingDown.get() || ticksPaused.get() },
                     )
                 // Route the NOTIFY callback through the worker's own single-thread executor so
                 // that push-driven ticks never run concurrently with the scheduled tick — each
@@ -221,6 +231,24 @@ class PostgresMessageQueue(
      */
     val requiredConnectionCount: Int
         get() = topicsToCoroutines.size
+
+    /**
+     * Pauses the scheduled-tick path on every active subscription, including the internal
+     * sleep-handler. Currently in-flight ticks are still allowed to finish; after a brief wait
+     * (longer than the tick interval) no new tick will start until [resumeTicks] is called.
+     *
+     * Intended for test fixtures that need to TRUNCATE Scoop's tables without racing live ticks
+     * (TRUNCATE's `AccessExclusiveLock` deadlocks with the tick's `AccessShareLock`). Production
+     * code should not need this — application shutdown uses [close] instead.
+     */
+    fun pauseTicks() {
+        ticksPaused.set(true)
+    }
+
+    /** Re-enables the scheduled-tick path. Companion to [pauseTicks]. */
+    fun resumeTicks() {
+        ticksPaused.set(false)
+    }
 
     /**
      * Stops the internal sleep-handler subscription. Application-owned subscriptions returned by

--- a/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/ScoopProducer.kt
+++ b/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/ScoopProducer.kt
@@ -13,6 +13,7 @@ import io.github.gabrielshanahan.scoop.messaging.PostgresMessageQueue
 import io.github.gabrielshanahan.scoop.messaging.TopicNotifier
 import io.vertx.pgclient.pubsub.PgSubscriber
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Disposes
 import jakarta.enterprise.inject.Produces
 import java.time.Duration
 import org.codejargon.fluentjdbc.api.FluentJdbc
@@ -93,4 +94,15 @@ class ScoopProducer(
             eventLoop,
             Duration.ofMillis(tickIntervalMs),
         )
+
+    /**
+     * Closes [PostgresMessageQueue]'s internal sleep-handler subscription on bean destroy so its
+     * periodic tick stops before Quarkus tears down the Agroal [DataSource][javax.sql.DataSource].
+     * Without this disposer the sleep-handler ticker keeps polling Postgres through Quarkus
+     * shutdown and produces "Error in when ticking" log spam every time the surrounding test or
+     * application exits.
+     */
+    fun disposeMessageQueue(@Disposes messageQueue: PostgresMessageQueue) {
+        messageQueue.close()
+    }
 }

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/StructuredCooperationTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/StructuredCooperationTest.kt
@@ -28,9 +28,21 @@ abstract class StructuredCooperationTest {
 
     @BeforeEach
     fun cleanupDatabase() {
-        fluentJdbc
-            .query()
-            .update("TRUNCATE TABLE message_event, message, return_value CASCADE")
-            .run()
+        // Pause the always-on internal sleep-handler subscription's periodic tick before
+        // TRUNCATE. Without the pause, TRUNCATE's AccessExclusiveLock deadlocks with the
+        // tick's AccessShareLock from `SELECT FOR UPDATE SKIP LOCKED`. The pause flag is
+        // checked by the scheduled-tick path, so new ticks won't start; sleeping slightly
+        // longer than the tick interval lets any in-flight tick drain before TRUNCATE runs.
+        messageQueue.pauseTicks()
+        try {
+            // 60 ms = tick interval (50 ms) + safety margin.
+            Thread.sleep(60)
+            fluentJdbc
+                .query()
+                .update("TRUNCATE TABLE message_event, message, return_value CASCADE")
+                .run()
+        } finally {
+            messageQueue.resumeTicks()
+        }
     }
 }

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/shutdownrepro/ReproSubscriptionRegistrar.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/shutdownrepro/ReproSubscriptionRegistrar.kt
@@ -1,0 +1,47 @@
+package io.github.gabrielshanahan.scoop.messaging.shutdownrepro
+
+import io.github.gabrielshanahan.scoop.coroutine.builder.saga
+import io.github.gabrielshanahan.scoop.messaging.HandlerRegistry
+import io.github.gabrielshanahan.scoop.messaging.PostgresMessageQueue
+import io.github.gabrielshanahan.scoop.messaging.Subscription
+import io.github.gabrielshanahan.scoop.messaging.eventLoopStrategy
+import io.quarkus.runtime.Startup
+import jakarta.annotation.PreDestroy
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+
+// Hack-test fixture, not a production component. Mirrors topiari's SagaRegistrar
+// so that during Quarkus shutdown, @PreDestroy calls Subscription.close() while
+// the periodic-tick executors are still polling Postgres. Under broken scoop,
+// close() returns before in-flight ticks finish, so ticks fire during ArC/Agroal
+// teardown and log "Error in when ticking" repeatedly — that spam is the symptom
+// the recipe in this package is designed to capture.
+@Startup
+@ApplicationScoped
+class ReproSubscriptionRegistrar
+@Inject
+constructor(
+    private val messageQueue: PostgresMessageQueue,
+    private val handlerRegistry: HandlerRegistry,
+) {
+    private val subscriptions: List<Subscription> =
+        (0 until SUBSCRIPTION_COUNT).map { i ->
+            val topic = "scoop-shutdown-repro-$i"
+            messageQueue.subscribe(
+                topic,
+                saga(topic, handlerRegistry.eventLoopStrategy()) { step { _, _ -> } },
+            )
+        }
+
+    val subscriptionCount: Int
+        get() = subscriptions.size
+
+    @PreDestroy
+    fun cleanup() {
+        subscriptions.forEach { runCatching { it.close() } }
+    }
+
+    companion object {
+        const val SUBSCRIPTION_COUNT = 20
+    }
+}

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/shutdownrepro/ShutdownSpamReproTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/shutdownrepro/ShutdownSpamReproTest.kt
@@ -37,8 +37,7 @@ class ShutdownSpamReproTest {
     // Direct @Inject forces the registrar to be instantiated; we don't rely on
     // @Startup eagerness, which has historically been flaky for beans declared
     // in src/test/kotlin under @TestProfile-isolated containers.
-    @Inject
-    lateinit var registrar: ReproSubscriptionRegistrar
+    @Inject lateinit var registrar: ReproSubscriptionRegistrar
 
     @Test
     fun `subscriptions leak past test end so quarkus shutdown races scoop ticks`() {

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/shutdownrepro/ShutdownSpamReproTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/shutdownrepro/ShutdownSpamReproTest.kt
@@ -1,0 +1,52 @@
+package io.github.gabrielshanahan.scoop.messaging.shutdownrepro
+
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Test
+
+// Hack-test, not a clean unit test. The work is done by ReproSubscriptionRegistrar
+// (eagerly @Startup, leaks subscriptions across the test boundary). This test method
+// only exists to make Quarkus boot. The reproduction signal lands in the gradle log
+// AFTER the test completes, while Quarkus is shutting down the test container —
+// see plan in /Users/gabriel.shanahan/.claude/plans/here-s-the-description-of-federated-clover.md
+// and the recipe in repro-findings.md for how to interpret the captured log.
+//
+// @TestProfile forces Quarkus to use a fresh container for this class (any non-default
+// config override does the job), so the subscriptions leaked here and the @PreDestroy
+// teardown they trigger don't contaminate the default-profile container shared by
+// the rest of scoop-quarkus's test classes.
+@QuarkusTest
+@TestProfile(ShutdownSpamReproTest.IsolationProfile::class)
+class ShutdownSpamReproTest {
+
+    class IsolationProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> =
+            mapOf(
+                // Forces fresh Quarkus container so the leaked subscriptions
+                // and the DataSource we'll race against don't pollute other classes.
+                "scoop.repro.isolation" to "true",
+                // Tick as fast as possible so the scheduled-tick path is essentially
+                // always running. Maximises the chance that close() lands on top of
+                // an in-flight tick, which is the in-flight that races Agroal teardown.
+                "scoop.tick-interval-ms" to "1",
+            )
+    }
+
+    // Direct @Inject forces the registrar to be instantiated; we don't rely on
+    // @Startup eagerness, which has historically been flaky for beans declared
+    // in src/test/kotlin under @TestProfile-isolated containers.
+    @Inject
+    lateinit var registrar: ReproSubscriptionRegistrar
+
+    @Test
+    fun `subscriptions leak past test end so quarkus shutdown races scoop ticks`() {
+        // Touch the injected registrar so the field is read (some Quarkus injection
+        // proxies are only resolved on first access, not on field assignment).
+        check(registrar.subscriptionCount == ReproSubscriptionRegistrar.SUBSCRIPTION_COUNT)
+        // Sleep briefly so several normal scheduled ticks happen on a healthy
+        // DataSource before the test method returns and Quarkus begins teardown.
+        Thread.sleep(200)
+    }
+}


### PR DESCRIPTION
## Summary

Two related fixes to scoop's tick lifecycle, motivated by reproducible log spam during application shutdown and intermittent deadlocks in scoop's own test suite.

### Commit 1 — block `Subscription.close()` until in-flight ticks have drained
- `PeriodicTick.close()` now follows `executor.shutdown()` with `awaitTermination(10s)`, falling back to `shutdownNow() + awaitTermination(2s)` if the soft timeout fires.
- `PostgresMessageQueue` implements `AutoCloseable` and owns the previously-anonymous internal sleep-handler subscription; the Quarkus `ScoopProducer` registers a CDI `@Disposes` method that closes the queue on bean destroy.
- `EventLoop.tickPeriodically` accepts an `isShuttingDown: () -> Boolean` callback (default `{ false }` — backwards-compatible). The scheduled-tick path becomes a no-op once it flips, and the outer try/catch in `tick()` demotes the failure log to DEBUG. `PostgresMessageQueue.close()` flips this flag before closing the sleep subscription, suppressing the racy log lines that fire while Quarkus tears down Agroal in parallel with `@PreDestroy`.
- New deterministic repro test under `scoop-quarkus/src/test/kotlin/.../shutdownrepro/`. Pre-fix: 5/5 runs produced 42–113 `Error in when ticking` lines per run, with both `pool is closed` and `ArC container not initialized` variants. Post-fix: 5/5 runs report 0.

### Commit 2 — `pauseTicks` / `resumeTicks` for test cleanup
- The always-on internal sleep-handler tick holds `AccessShareLock` on `message_event` via `SELECT FOR UPDATE SKIP LOCKED`. `StructuredCooperationTest.cleanupDatabase()`'s `TRUNCATE` needs `AccessExclusiveLock` and intermittently deadlocks with it (~40% of full-suite runs failed pre-fix, with different test classes reporting the failure each time).
- Adds reversible `PostgresMessageQueue.pauseTicks()` / `resumeTicks()` — flips a `ticksPaused` `AtomicBoolean` that gates the same scheduled-tick path the shutdown flag uses.
- `cleanupDatabase()` now pauses → sleeps slightly past the tick interval to let in-flight ticks drain → `TRUNCATE` → `resume` (in `try/finally`).
- Full `:scoop-quarkus:test` suite: 3/5 → 5/5 green across five back-to-back runs.

## Test plan
- [x] `./gradlew :scoop-quarkus:test --tests "*ShutdownSpamReproTest" --rerun-tasks --info` reports 0 `Error in when ticking` lines, 5/5 runs.
- [x] `./gradlew :scoop-quarkus:test --rerun-tasks` passes 5/5 back-to-back.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)