### PR TITLE
chore: drop external-project references and dev-machine paths from test comments

### DIFF
--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/StubHandlerBlockingTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/StubHandlerBlockingTest.kt
@@ -22,9 +22,10 @@ import org.junit.jupiter.api.TestInstance
  * Tests that a saga step properly blocks when a handler is registered in the topology but NOT
  * subscribed to the event loop (a "stub handler").
  *
- * This reproduces the scenario from Topiari where a "HumanHandler" is declared in the topology for
- * the "who is listening" check, but is never actually subscribed. The expectation is that the
- * parent saga does NOT resume until someone externally writes SEEN + COMMITTED events for the stub
+ * Models the pattern where a handler is declared in the topology purely to satisfy the "who is
+ * listening" check, but is never actually subscribed in-process — for example, a human-driven step
+ * where a user (or some external system) is expected to write SEEN + COMMITTED events out-of-band.
+ * The expectation is that the parent saga does NOT resume until those events appear for the stub
  * handler.
  */
 @QuarkusTest
@@ -35,8 +36,8 @@ class StubHandlerBlockingTest : StructuredCooperationTest() {
     private val stubHandlerName = "stub-handler"
 
     /**
-     * Creates an event loop strategy that includes the stub handler in the topology, simulating
-     * what Topiari does with HumanHandler.
+     * Creates an event loop strategy that includes the stub handler in the topology, modelling the
+     * human-handler / out-of-band-COMMITTED pattern described in the class kdoc.
      */
     private fun strategyWithStubHandler() =
         StandardEventLoopStrategy(OffsetDateTime.now()) {

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/shutdownrepro/ReproSubscriptionRegistrar.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/shutdownrepro/ReproSubscriptionRegistrar.kt
@@ -10,12 +10,12 @@ import jakarta.annotation.PreDestroy
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 
-// Hack-test fixture, not a production component. Mirrors topiari's SagaRegistrar
-// so that during Quarkus shutdown, @PreDestroy calls Subscription.close() while
-// the periodic-tick executors are still polling Postgres. Under broken scoop,
-// close() returns before in-flight ticks finish, so ticks fire during ArC/Agroal
-// teardown and log "Error in when ticking" repeatedly — that spam is the symptom
-// the recipe in this package is designed to capture.
+// Hack-test fixture, not a production component. Models the typical application-side pattern:
+// a CDI bean that registers subscriptions on startup and closes them in @PreDestroy. The
+// shutdown contract under test is that close() must drain in-flight ticks before returning, so
+// when Quarkus tears down ArC and Agroal in parallel with @PreDestroy, no tick keeps running
+// against a half-closed DataSource. Without that contract, the executors keep polling and
+// produce the "Error in when ticking" log spam this package's recipe captures.
 @Startup
 @ApplicationScoped
 class ReproSubscriptionRegistrar

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/shutdownrepro/ShutdownSpamReproTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/shutdownrepro/ShutdownSpamReproTest.kt
@@ -9,9 +9,8 @@ import org.junit.jupiter.api.Test
 // Hack-test, not a clean unit test. The work is done by ReproSubscriptionRegistrar
 // (eagerly @Startup, leaks subscriptions across the test boundary). This test method
 // only exists to make Quarkus boot. The reproduction signal lands in the gradle log
-// AFTER the test completes, while Quarkus is shutting down the test container —
-// see plan in /Users/gabriel.shanahan/.claude/plans/here-s-the-description-of-federated-clover.md
-// and the recipe in repro-findings.md for how to interpret the captured log.
+// AFTER the test completes, while Quarkus is shutting down the test container — grep the
+// captured log for "Error in when ticking" to see the symptom (zero matches under the fix).
 //
 // @TestProfile forces Quarkus to use a fresh container for this class (any non-default
 // config override does the job), so the subscriptions leaked here and the @PreDestroy


### PR DESCRIPTION
## Summary
Addresses the two review comments on #40:

- **`ReproSubscriptionRegistrar.kt`** + **`StubHandlerBlockingTest.kt`** — both referenced an external project by name in their kdoc/header comments. Replaced with a description of the pattern the fixture models, with no reference to the downstream project.
- **`ShutdownSpamReproTest.kt`** — class kdoc cited an absolute path (`/Users/...`) to a plan file that only exists on the dev machine the original PR was authored on and is not part of the repo. Removed; also dropped the adjacent reference to `repro-findings.md` (also dev-machine-local).

No production code touched. No behaviour change.

## Test plan
- [x] `./gradlew ktfmtCheck detekt` clean
- [x] `./gradlew :scoop-quarkus:test --tests "*ShutdownSpamReproTest" --rerun-tasks --info` reports 0 `Error in when ticking`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)