### PR TITLE
feat: TransactionRunner seam — run saga steps in a JTA transaction under Quarkus

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -49,6 +49,7 @@
     <ID>MagicNumber:util.kt$999999000</ID>
     <ID>MagicNumber:EventLoop.kt$EventLoop$0.02</ID>
     <ID>TooManyFunctions:EventLoop.kt$EventLoop</ID>
+    <ID>TooManyFunctions:ScoopProducer.kt$ScoopProducer</ID>
     <ID>MagicNumber:utils.kt$0.02</ID>
     <ID>MatchingDeclarationName:PendingCoroutineRunSql.kt$SQL</ID>
     <ID>MaxLineLength:DeadlineTest.kt$DeadlineTest$"[root handler] MissedHappyPathDeadline: Missed happy path deadline of root handler at ${deadline.get().deadline.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)}. Deadline trace: [{\"HappyPathDeadlineKey\": {\"trace\": [], \"source\": \"root system\", \"deadline\": \"9999-12-31T23:59:59.999999Z\"}}]"</ID>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ quarkus-jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson
 quarkus-jdbc-postgresql = { module = "io.quarkus:quarkus-jdbc-postgresql" }
 quarkus-fluentjdbc = { module = "io.quarkiverse.fluentjdbc:quarkus-fluentjdbc", version.ref = "quarkus-fluentjdbc" }
 quarkus-reactive-pg-client = { module = "io.quarkus:quarkus-reactive-pg-client" }
+quarkus-narayana-jta = { module = "io.quarkus:quarkus-narayana-jta" }
 quarkus-arc = { module = "io.quarkus:quarkus-arc" }
 quarkus-kotlin = { module = "io.quarkus:quarkus-kotlin" }
 quarkus-junit5 = { module = "io.quarkus:quarkus-junit5" }

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/Scoop.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/Scoop.kt
@@ -3,6 +3,7 @@ package io.github.gabrielshanahan.scoop
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import io.github.gabrielshanahan.scoop.coroutine.EventLoop
+import io.github.gabrielshanahan.scoop.coroutine.FluentJdbcTransactionRunner
 import io.github.gabrielshanahan.scoop.coroutine.context.CooperationContextModule
 import io.github.gabrielshanahan.scoop.coroutine.structuredcooperation.Capabilities
 import io.github.gabrielshanahan.scoop.coroutine.structuredcooperation.MessageEventRepository
@@ -63,7 +64,15 @@ private constructor(
             val returnValueRepository = ReturnValueRepository(fluentJdbc)
             val capabilities =
                 Capabilities(messageRepository, messageEventRepository, returnValueRepository)
-            val eventLoop = EventLoop(fluentJdbc, messageEventRepository, capabilities, jsonbHelper)
+            val transactionRunner = FluentJdbcTransactionRunner(fluentJdbc)
+            val eventLoop =
+                EventLoop(
+                    fluentJdbc,
+                    messageEventRepository,
+                    capabilities,
+                    jsonbHelper,
+                    transactionRunner,
+                )
             val messageQueue =
                 PostgresMessageQueue(
                     topicNotifier,

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
@@ -87,6 +87,7 @@ class EventLoop(
     private val messageEventRepository: MessageEventRepository,
     private val scopeCapabilities: ScopeCapabilities,
     private val jsonbHelper: JsonbHelper,
+    private val transactionRunner: TransactionRunner = FluentJdbcTransactionRunner(fluentJdbc),
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -149,7 +150,7 @@ class EventLoop(
             }
 
             whileISaySo { repeatCount, saySo ->
-                fluentJdbc.transactional { connection ->
+                transactionRunner.inStepTransaction { connection ->
                     try {
                         logger.debug(
                             "Run number $repeatCount for topic $topic and coroutine ${distributedCoroutine.identifier}"
@@ -157,7 +158,7 @@ class EventLoop(
                         val coroutineState =
                             fetchSomePendingCoroutineState(connection, distributedCoroutine)
                         if (coroutineState == null) {
-                            return@transactional
+                            return@inStepTransaction
                         }
                         saySo()
                         val continuationResult =

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/TransactionRunner.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/TransactionRunner.kt
@@ -1,0 +1,49 @@
+package io.github.gabrielshanahan.scoop.coroutine
+
+import io.github.gabrielshanahan.scoop.transactional
+import java.sql.Connection
+import org.codejargon.fluentjdbc.api.FluentJdbc
+
+/**
+ * Owns the database transaction that wraps a single saga step.
+ *
+ * Each tick of the [EventLoop] resumes one saga step inside a transaction. Scoop's own
+ * `message_event` writes happen on the [Connection] handed to [inStepTransaction], and so does any
+ * business code the step calls. Keeping those writes in one transaction is what makes a step
+ * atomic: either the business effect and the structured-cooperation bookkeeping both commit, or
+ * both roll back.
+ *
+ * This seam exists so integrations can decide *how* that per-step transaction is managed. The
+ * framework-agnostic default ([FluentJdbcTransactionRunner]) opens and manages its own plain JDBC
+ * transaction. A JTA-based integration (e.g. Quarkus/Narayana) can instead begin a container
+ * transaction and hand back the transaction-enlisted connection, so that business code annotated
+ * with `@Transactional` joins the very same transaction on the very same connection as scoop's
+ * writes.
+ *
+ * Only the per-step transaction is routed through this seam. The other transactions in the event
+ * loop (starting continuations, and the separate-thread rollback markers) run no business code and
+ * deliberately remain plain self-managed transactions.
+ */
+interface TransactionRunner {
+    /**
+     * Runs [block] inside the per-step transaction, passing it the transaction's [Connection].
+     *
+     * The transaction is committed if [block] returns normally and rolled back if it throws.
+     *
+     * @param block the step work to run; receives the transaction-bound connection
+     * @return whatever [block] returns
+     */
+    fun <T> inStepTransaction(block: (Connection) -> T): T
+}
+
+/**
+ * Default [TransactionRunner] that manages its own plain JDBC transaction via [FluentJdbc].
+ *
+ * Behaves exactly like calling [fluentJdbc].[transactional][transactional] directly: autocommit
+ * off, commit on normal return, rollback on throw. This preserves Scoop's plain-JVM behavior
+ * unchanged.
+ */
+class FluentJdbcTransactionRunner(private val fluentJdbc: FluentJdbc) : TransactionRunner {
+    override fun <T> inStepTransaction(block: (Connection) -> T): T =
+        fluentJdbc.transactional(block)
+}

--- a/scoop-quarkus/build.gradle.kts
+++ b/scoop-quarkus/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(libs.quarkus.jdbc.postgresql)
     implementation(libs.quarkus.fluentjdbc)
     implementation(libs.quarkus.reactive.pg.client)
+    implementation(libs.quarkus.narayana.jta)
     implementation(libs.quarkus.arc)
     implementation(libs.quarkus.kotlin)
     testImplementation(libs.quarkus.junit5)

--- a/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/JtaTransactionRunner.kt
+++ b/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/JtaTransactionRunner.kt
@@ -1,0 +1,22 @@
+package io.github.gabrielshanahan.scoop.quarkus
+
+import io.github.gabrielshanahan.scoop.coroutine.TransactionRunner
+import io.quarkus.narayana.jta.QuarkusTransaction
+import java.sql.Connection
+import javax.sql.DataSource
+
+/**
+ * [TransactionRunner] that runs each saga step inside a fresh JTA (Narayana) transaction.
+ *
+ * [QuarkusTransaction.requiringNew] begins a new container transaction; the [Connection] obtained
+ * from the Agroal [dataSource] inside that transaction is automatically enlisted in it. Because
+ * Agroal returns the same transaction-enlisted connection for every acquisition within a single JTA
+ * transaction, any business code annotated with `@Transactional(REQUIRED)` that the step calls
+ * joins this exact transaction on this exact connection. Scoop's `message_event` writes therefore
+ * become atomic with the business writes: the transaction commits on normal return and rolls back
+ * on throw.
+ */
+class JtaTransactionRunner(private val dataSource: DataSource) : TransactionRunner {
+    override fun <T> inStepTransaction(block: (Connection) -> T): T =
+        QuarkusTransaction.requiringNew().call { dataSource.connection.use { conn -> block(conn) } }
+}

--- a/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/ScoopProducer.kt
+++ b/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/ScoopProducer.kt
@@ -3,6 +3,7 @@ package io.github.gabrielshanahan.scoop.quarkus
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.gabrielshanahan.scoop.JsonbHelper
 import io.github.gabrielshanahan.scoop.coroutine.EventLoop
+import io.github.gabrielshanahan.scoop.coroutine.TransactionRunner
 import io.github.gabrielshanahan.scoop.coroutine.structuredcooperation.Capabilities
 import io.github.gabrielshanahan.scoop.coroutine.structuredcooperation.MessageEventRepository
 import io.github.gabrielshanahan.scoop.coroutine.structuredcooperation.ReturnValueRepository
@@ -16,6 +17,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Disposes
 import jakarta.enterprise.inject.Produces
 import java.time.Duration
+import javax.sql.DataSource
 import org.codejargon.fluentjdbc.api.FluentJdbc
 import org.eclipse.microprofile.config.inject.ConfigProperty
 
@@ -30,6 +32,7 @@ class ScoopProducer(
     private val fluentJdbc: FluentJdbc,
     private val objectMapper: ObjectMapper,
     private val pgSubscriber: PgSubscriber,
+    private val dataSource: DataSource,
     @ConfigProperty(name = "scoop.tick-interval-ms", defaultValue = "50")
     private val tickIntervalMs: Long,
 ) {
@@ -71,13 +74,30 @@ class ScoopProducer(
     @ApplicationScoped
     fun topicNotifier(): TopicNotifier = PgSubscriberTopicNotifier(pgSubscriber)
 
+    /**
+     * Produces the per-step [TransactionRunner]. Under Quarkus this is JTA-backed so that scoop's
+     * `message_event` writes and any `@Transactional` business code a step calls share the same
+     * Narayana transaction on the same Agroal connection, making the step atomic.
+     */
+    @Produces
+    @ApplicationScoped
+    fun transactionRunner(): TransactionRunner = JtaTransactionRunner(dataSource)
+
     @Produces
     @ApplicationScoped
     fun eventLoop(
         messageEventRepository: MessageEventRepository,
         scopeCapabilities: ScopeCapabilities,
         jsonbHelper: JsonbHelper,
-    ): EventLoop = EventLoop(fluentJdbc, messageEventRepository, scopeCapabilities, jsonbHelper)
+        transactionRunner: TransactionRunner,
+    ): EventLoop =
+        EventLoop(
+            fluentJdbc,
+            messageEventRepository,
+            scopeCapabilities,
+            jsonbHelper,
+            transactionRunner,
+        )
 
     @Produces
     @ApplicationScoped

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/JtaAtomicityTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/JtaAtomicityTest.kt
@@ -1,0 +1,184 @@
+package io.github.gabrielshanahan.scoop.coroutine.structuredcooperation
+
+import io.github.gabrielshanahan.scoop.coroutine.StructuredCooperationTest
+import io.github.gabrielshanahan.scoop.coroutine.builder.saga
+import io.github.gabrielshanahan.scoop.coroutine.ciSleep
+import io.github.gabrielshanahan.scoop.messaging.eventLoopStrategy
+import io.github.gabrielshanahan.scoop.transactional
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import jakarta.transaction.Transactional
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.sql.DataSource
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Proves that a JTA `@Transactional` business write performed inside a saga step is atomic with
+ * scoop's own `message_event` writes — i.e. both are part of the one per-step JTA transaction begun
+ * by [io.github.gabrielshanahan.scoop.quarkus.JtaTransactionRunner].
+ *
+ * Before this seam existed, calling `@Transactional` business code from a step threw Agroal's
+ * "Deferred enlistment not supported", because scoop's step ran on a non-JTA connection while the
+ * business code tried to start its own JTA transaction.
+ */
+/**
+ * Dedicated exception so a step can fail deterministically without tripping detekt's generic-throw
+ * rule.
+ */
+private class SimulatedStepFailure(message: String) : Exception(message)
+
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JtaAtomicityTest : StructuredCooperationTest() {
+
+    /** Business bean that writes to a business table inside a `@Transactional(REQUIRED)` method. */
+    @ApplicationScoped
+    open class ProbeWriter(private val dataSource: DataSource) {
+        @Transactional
+        open fun write(id: String) {
+            dataSource.connection.use { conn ->
+                conn.prepareStatement("INSERT INTO scoop_jta_probe (id) VALUES (?)").use { ps ->
+                    ps.setString(1, id)
+                    ps.executeUpdate()
+                }
+            }
+        }
+    }
+
+    @Inject lateinit var probeWriter: ProbeWriter
+
+    @Inject lateinit var dataSource: DataSource
+
+    @BeforeEach
+    fun createProbeTable() {
+        fluentJdbc
+            .query()
+            .update("CREATE TABLE IF NOT EXISTS scoop_jta_probe (id text PRIMARY KEY)")
+            .run()
+        fluentJdbc.query().update("TRUNCATE TABLE scoop_jta_probe").run()
+    }
+
+    private fun probeRowExists(id: String): Boolean =
+        dataSource.connection.use { conn ->
+            conn.prepareStatement("SELECT 1 FROM scoop_jta_probe WHERE id = ?").use { ps ->
+                ps.setString(1, id)
+                ps.executeQuery().use { rs -> rs.next() }
+            }
+        }
+
+    private fun eventTypesFor(coroutineName: String): List<String> =
+        fluentJdbc
+            .query()
+            .select(
+                "SELECT type FROM message_event WHERE coroutine_name = :name ORDER BY created_at"
+            )
+            .namedParam("name", coroutineName)
+            .listResult { it.getString("type") }
+
+    @Test
+    fun `business write inside a step commits atomically with scoop events`() {
+        val probeId = "commit-${java.util.UUID.randomUUID()}"
+        val latch = CountDownLatch(1)
+
+        val subscription =
+            messageQueue.subscribe(
+                rootTopic,
+                saga("jta-commit-handler", handlerRegistry.eventLoopStrategy()) {
+                    step { scope, message ->
+                        // A child launch ensures the step's connection (used by scope.launch)
+                        // is the same JTA-enlisted connection as the business write.
+                        val childPayload = jsonbHelper.toPGobject(mapOf("from" to "jta"))
+                        scope.launch(childTopic, childPayload)
+                        probeWriter.write(probeId)
+                        latch.countDown()
+                    }
+                },
+            )
+
+        val childSubscription =
+            messageQueue.subscribe(
+                childTopic,
+                saga("jta-commit-child", handlerRegistry.eventLoopStrategy()) {
+                    step { scope, message -> }
+                },
+            )
+
+        try {
+            val rootPayload = jsonbHelper.toPGobject(mapOf("initial" to "true"))
+            fluentJdbc.transactional { connection ->
+                messageQueue.launch(connection, rootTopic, rootPayload)
+            }
+
+            Assertions.assertTrue(
+                latch.await(10, TimeUnit.SECONDS),
+                "Step did not run (deferred-enlistment would prevent it)",
+            )
+            ciSleep(500)
+
+            // (a) it did NOT throw deferred-enlistment: the step ran and committed
+            // (b) the business row is present
+            Assertions.assertTrue(
+                probeRowExists(probeId),
+                "Business write should have committed with the step",
+            )
+            // (c) scoop's SUSPENDED + COMMITTED events for this saga exist
+            val events = eventTypesFor("jta-commit-handler")
+            Assertions.assertTrue(
+                events.contains("SUSPENDED"),
+                "Expected a SUSPENDED event, got $events",
+            )
+            Assertions.assertTrue(
+                events.contains("COMMITTED"),
+                "Expected a COMMITTED event, got $events",
+            )
+        } finally {
+            subscription.close()
+            childSubscription.close()
+        }
+    }
+
+    @Test
+    fun `business write rolls back together with the step when the step throws`() {
+        val probeId = "rollback-${java.util.UUID.randomUUID()}"
+        val latch = CountDownLatch(1)
+
+        val subscription =
+            messageQueue.subscribe(
+                rootTopic,
+                saga("jta-rollback-handler", handlerRegistry.eventLoopStrategy()) {
+                    step(
+                        invoke = { scope, message ->
+                            probeWriter.write(probeId)
+                            latch.countDown()
+                            throw SimulatedStepFailure("Simulated failure after business write")
+                        },
+                        rollback = { scope, message, throwable -> },
+                    )
+                },
+            )
+
+        try {
+            val rootPayload = jsonbHelper.toPGobject(mapOf("initial" to "true"))
+            fluentJdbc.transactional { connection ->
+                messageQueue.launch(connection, rootTopic, rootPayload)
+            }
+
+            Assertions.assertTrue(latch.await(10, TimeUnit.SECONDS), "Step did not run")
+            ciSleep(500)
+
+            // The business write and scoop's step tx are one unit: since the step threw,
+            // the business row must have been rolled back with it.
+            Assertions.assertFalse(
+                probeRowExists(probeId),
+                "Business write should have rolled back with the failed step",
+            )
+        } finally {
+            subscription.close()
+        }
+    }
+}


### PR DESCRIPTION
## Problem
A saga step's structured-cooperation effects (the `EMITTED` of any launched children + the `SUSPENDED` marker) must commit **atomically** with the business work the step performs — otherwise you get the dual-write split (business committed but children never launched, or vice versa).

Today scoop runs each step in its own FluentJDBC-managed transaction on an Agroal connection acquired *outside* JTA. When business code annotated `@Transactional` is called from a step, the CDI interceptor starts a Narayana transaction on a thread that already holds that connection, and Agroal refuses: **"Deferred enlistment not supported."** Net effect: JTA `@Transactional` business code **cannot run inside a saga step at all**.

## Fix
A `TransactionRunner` seam (in scoop-core, framework-agnostic) owns the per-step transaction:

- **`FluentJdbcTransactionRunner`** (default) = today's `fluentJdbc.transactional { … }`. Zero behaviour change for plain-JVM users; `EventLoop`'s new param is defaulted to it, and `Scoop.create` wires it.
- **Only the step-tx call site** (the `whileISaySo` loop) routes through the seam. The three scoop-internal transactions — `startContinuationsForCoroutine` and the two separate-thread rollback markers — are **untouched** (they run no business code and are deliberately separate).
- **scoop-quarkus** supplies **`JtaTransactionRunner`**: `QuarkusTransaction.requiringNew()` with the Agroal connection acquired *inside* that transaction (so it is enlisted). Within one JTA tx, Agroal hands back the same enlisted connection for every acquisition — so any `@Transactional(REQUIRED)` business code the step calls joins the step's transaction on the same connection. scoop's `message_event` writes and the business writes commit/roll back as **one unit**.

## Proof
`JtaAtomicityTest` (`@QuarkusTest`): a step that writes through a `@Transactional` bean (a) does **not** throw deferred-enlistment and commits the row together with scoop's `SUSPENDED`/`COMMITTED` events, and (b) when it throws, the row is rolled back **with** the step. The entire existing scoop-quarkus suite passes while running every step under the JTA runner — confirming no regression to existing sagas.

`./gradlew build` green (scoop-core + scoop-quarkus, ktfmt + detekt).