### PR TITLE
fix: never roll a saga back when Scoop's own bookkeeping fails

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Fixed
+
+- A transient failure of Scoop's **own** persistence (most often a dead/idle-closed JDBC connection used during its bookkeeping — `giveUpIfNecessary`, an emission write, a `message_event` write) no longer rolls the saga back. Such failures are now classified as `ScoopInfrastructureException` (wrapped at the repository boundary) and treated by the event loop as a transient tick failure: the tick's transaction is rolled back and the run is re-resumed from its last committed step on a later tick. Previously any exception raised while processing a step — including one from Scoop's own machinery — became a `Failure` and drove the saga into `ROLLING_BACK`, which for a perpetual (infinite-`GoTo`) saga unwound the entire accumulated loop history and killed the loop for good. Only failures originating in the saga-defining code (`invoke` / `rollback` / `handleChildFailures`) still drive rollback; deliberate logical signals (`ReturnValueAlreadyExistsException`, the `ScoopException` control signals) pass through unchanged, and `Error`s (OOM, …) are never caught.
+
+### Added
+
+- `scoop.retry.infra-backoff-base` / `scoop.retry.infra-backoff-max` (both default `0s` = retry on the very next tick): opt-in exponential backoff (`base * 2^(attempt-1)`, capped at the max) between retries after a `ScoopInfrastructureException`, so a persistently-dead connection is not retried on every tick.
+
 ## v0.3.0 — 2026-06-13
 
 ## v0.2.11 — 2026-05-02

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
@@ -20,11 +20,13 @@ import java.sql.Connection
 import java.time.Duration
 import java.time.Instant
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
+import kotlin.math.pow
 import org.codejargon.fluentjdbc.api.FluentJdbc
 import org.postgresql.jdbc.PgConnection
 import org.slf4j.LoggerFactory
@@ -82,16 +84,55 @@ private const val SHUTDOWN_INTERRUPT_TIMEOUT_SECONDS = 2L
  * [PostgresMessageQueue.subscribe][io.github.gabrielshanahan.scoop.messaging.PostgresMessageQueue.subscribe]
  * to understand how this works.\
  */
+@Suppress("LongParameterList")
 class EventLoop(
     private val fluentJdbc: FluentJdbc,
     private val messageEventRepository: MessageEventRepository,
     private val scopeCapabilities: ScopeCapabilities,
     private val jsonbHelper: JsonbHelper,
     private val transactionRunner: TransactionRunner = FluentJdbcTransactionRunner(fluentJdbc),
+    // Exponential backoff for retries after a [ScoopInfrastructureException] (see below). Default
+    // ZERO base = "retry on every tick" (no added delay, no behavioural change vs. always-resume).
+    private val retryBackoffBase: Duration = Duration.ZERO,
+    private val retryBackoffMax: Duration = Duration.ZERO,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     private fun Connection.backendPID(): Int = unwrap(PgConnection::class.java).backendPID
+
+    // ---- Infrastructure-failure retry backoff ---------------------------------------------------
+    // When resuming a saga throws a [ScoopInfrastructureException] (Scoop's OWN bookkeeping failed,
+    // e.g. a dead connection — NOT a saga-logic failure), the saga is NOT rolled back: the tick's
+    // transaction is rolled back and the saga is retried on a later tick. By default that retry
+    // happens on the very next tick. These two knobs let a caller spread retries out exponentially
+    // (base * 2^(attempt-1), capped at [retryBackoffMax]) so a persistently-dead connection is not
+    // hammered every tick. State is in-memory and per-run (keyed by the run's root message id):
+    // attempts reset to "retry immediately" whenever the run makes any progress, and are lost on a
+    // restart (a restart already retries from the last committed step, so that is harmless).
+    private val backoffAttempts = ConcurrentHashMap<UUID, Int>()
+    private val backoffUntil = ConcurrentHashMap<UUID, Instant>()
+
+    private fun isBackedOff(messageId: UUID): Boolean =
+        backoffUntil[messageId]?.let { Instant.now().isBefore(it) } ?: false
+
+    private fun recordInfraBackoff(messageId: UUID) {
+        if (retryBackoffBase.isZero) return // retry-every-tick: keep no state
+        val attempt = backoffAttempts.merge(messageId, 1, Int::plus) ?: 1
+        val rawMillis = retryBackoffBase.toMillis().toDouble() * 2.0.pow(attempt - 1)
+        val cappedMillis = minOf(rawMillis, retryBackoffMax.toMillis().toDouble()).toLong()
+        backoffUntil[messageId] = Instant.now().plusMillis(cappedMillis)
+        logger.debug(
+            "Infrastructure failure for run {}: attempt {}, backing off {}ms",
+            messageId,
+            attempt,
+            cappedMillis,
+        )
+    }
+
+    private fun clearBackoff(messageId: UUID) {
+        backoffAttempts.remove(messageId)
+        backoffUntil.remove(messageId)
+    }
 
     /**
      * Executes a single tick of the event loop for the given saga type.
@@ -125,6 +166,7 @@ class EventLoop(
      * @param topic The message topic this saga is subscribed to
      * @param distributedCoroutine The saga definition to execute
      */
+    @Suppress("LongMethod", "ThrowsCount")
     fun tick(
         topic: String,
         distributedCoroutine: DistributedCoroutine,
@@ -160,9 +202,30 @@ class EventLoop(
                         if (coroutineState == null) {
                             return@inStepTransaction
                         }
+                        val messageId = coroutineState.message.id
+                        // Honour an in-effect infrastructure-failure backoff: leave the run pending
+                        // and end this tick (no saySo) so it is retried on a later tick. With the
+                        // default ZERO backoff base this is never true (retry on every tick).
+                        if (isBackedOff(messageId)) {
+                            return@inStepTransaction
+                        }
                         saySo()
                         val continuationResult =
-                            resumeCoroutine(connection, distributedCoroutine, coroutineState)
+                            try {
+                                resumeCoroutine(connection, distributedCoroutine, coroutineState)
+                            } catch (e: ScoopInfrastructureException) {
+                                // Scoop's OWN bookkeeping failed (a dead connection, say) — NOT a
+                                // failure of saga logic. Do not roll the saga back: record a
+                                // backoff
+                                // and rethrow so this tick's transaction rolls back and the run is
+                                // retried, from its last committed step, on a later tick.
+                                recordInfraBackoff(messageId)
+                                throw e
+                            }
+
+                        // The run made progress (committed / suspended, or a genuine business-logic
+                        // rollback) — clear any infrastructure-failure backoff.
+                        clearBackoff(messageId)
 
                         if (continuationResult is Continuation.ContinuationResult.Failure) {
                             throw continuationResult.exception

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/ScoopInfrastructureException.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/ScoopInfrastructureException.kt
@@ -1,0 +1,58 @@
+package io.github.gabrielshanahan.scoop.coroutine
+
+import io.github.gabrielshanahan.scoop.coroutine.structuredcooperation.ReturnValueAlreadyExistsException
+
+/**
+ * Thrown when one of Scoop's OWN persistence operations fails — a query Scoop runs for its own
+ * bookkeeping (writing `message_event` rows, reading the give-up set, inserting emitted messages,
+ * storing/reading return values, …) — as opposed to anything the saga's own step code does.
+ *
+ * The overwhelmingly common cause is a dead/closed JDBC connection (e.g. one that rotted while idle
+ * and was then handed out of the pool). The defining property is that the failure originates
+ * **outside the code that defines the saga**, so it carries no information about whether the saga's
+ * business action should be compensated — and must therefore NEVER drive a rollback. The event loop
+ * treats it as a transient tick failure: the current tick's transaction is rolled back and the saga
+ * is re-resumed (retried) on a later tick from its last committed step, rather than unwinding the
+ * whole saga. This is what keeps a perpetual (infinite-`GoTo`) saga alive across a connection blip.
+ *
+ * Stack trace is suppressed (like the other [ScoopException]s) — the wrapped [cause] carries it.
+ *
+ * @param cause The underlying failure from Scoop's persistence layer (typically a SQL/connection
+ *   exception).
+ */
+class ScoopInfrastructureException(cause: Throwable) :
+    ScoopException(
+        "A Scoop bookkeeping operation failed (most often a dead JDBC connection). This is not a " +
+            "saga-logic failure and must not trigger rollback.",
+        cause,
+        false,
+    )
+
+/**
+ * Runs [block] — a Scoop-internal persistence operation — re-classifying any failure that is NOT a
+ * deliberate logical signal as a [ScoopInfrastructureException], so the event loop retries the tick
+ * instead of rolling the saga back. See [ScoopInfrastructureException] for the rationale.
+ *
+ * Pass-throughs (NOT wrapped, because they are meaningful outcomes rather than infrastructure
+ * faults):
+ * - any [ScoopException] (which includes [ScoopInfrastructureException] itself, plus the deliberate
+ *   control signals such as gave-up / cancellation / rollback-requested), and
+ * - [ReturnValueAlreadyExistsException] (a logical uniqueness outcome that callers branch on).
+ *
+ * [Error]s (OOM, StackOverflow, …) are deliberately NOT caught: an `Error` is not Scoop's verdict
+ * on the saga either, and must propagate untouched to fail the tick (or crash the process), never
+ * be swallowed into the retry path.
+ */
+// TooGenericExceptionCaught is the whole point: any non-logical failure of Scoop's own persistence
+// is reclassified as infrastructure, regardless of its concrete type. Errors are not caught.
+@Suppress("TooGenericExceptionCaught")
+internal inline fun <T> asScoopInfrastructure(block: () -> T): T =
+    try {
+        block()
+    } catch (e: ScoopException) {
+        throw e
+    } catch (e: ReturnValueAlreadyExistsException) {
+        throw e
+    } catch (e: Exception) {
+        throw ScoopInfrastructureException(e)
+    }

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/continuation/CooperationContinuation.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/continuation/CooperationContinuation.kt
@@ -5,6 +5,7 @@ import io.github.gabrielshanahan.scoop.coroutine.CooperationScopeIdentifier
 import io.github.gabrielshanahan.scoop.coroutine.DistributedCoroutine
 import io.github.gabrielshanahan.scoop.coroutine.Handler
 import io.github.gabrielshanahan.scoop.coroutine.NextStep
+import io.github.gabrielshanahan.scoop.coroutine.ScoopInfrastructureException
 import io.github.gabrielshanahan.scoop.coroutine.TransactionalStep
 import io.github.gabrielshanahan.scoop.coroutine.VariableName
 import io.github.gabrielshanahan.scoop.coroutine.context.CooperationContext
@@ -346,6 +347,13 @@ internal abstract class BaseCooperationContinuation(
 
             // Execute the step logic and check for give-up conditions that arose during execution
             handleFailuresOrResume(lastStepResult).also { giveUpIfNecessary() }
+        } catch (e: ScoopInfrastructureException) {
+            // Scoop's OWN bookkeeping failed (e.g. a dead JDBC connection during giveUpIfNecessary
+            // or an emission write) — NOT a failure of the saga-defining code. Rethrow rather than
+            // turning it into a Failure: tick() rolls back this tick's transaction and the saga is
+            // retried from its last committed step on a later tick, instead of the whole saga
+            // (possibly a perpetual loop) being rolled back. See [ScoopInfrastructureException].
+            throw e
         } catch (e: Exception) {
             Continuation.ContinuationResult.Failure(e)
         }

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/MessageEventRepository.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/MessageEventRepository.kt
@@ -1,6 +1,7 @@
 package io.github.gabrielshanahan.scoop.coroutine.structuredcooperation
 
 import io.github.gabrielshanahan.scoop.JsonbHelper
+import io.github.gabrielshanahan.scoop.coroutine.asScoopInfrastructure
 import io.github.gabrielshanahan.scoop.coroutine.context.CooperationContext
 import io.github.gabrielshanahan.scoop.coroutine.context.isNotEmpty
 import io.github.gabrielshanahan.scoop.coroutine.eventloop.strategy.EventLoopStrategy
@@ -41,23 +42,25 @@ class MessageEventRepository(
         cooperationLineage: List<UUID>,
         context: CooperationContext?,
     ) {
-        logger.debug("Inserting global EMITTED event: messageId={}", messageId)
-        fluentJdbc
-            .queryOn(connection)
-            .update(
-                "--${messageId} || ${cooperationLineage}\n" +
-                    "INSERT INTO message_event (message_id, type, cooperation_lineage, context) VALUES (:messageId, 'EMITTED', :cooperationLineage, :context)"
-            )
-            .namedParam("messageId", messageId)
-            .namedParam(
-                "cooperationLineage",
-                connection.createArrayOf("uuid", cooperationLineage.toTypedArray()),
-            )
-            .namedParam(
-                "context",
-                context?.takeIf { it.isNotEmpty() }?.let { jsonbHelper.toPGobject(it) },
-            )
-            .run()
+        asScoopInfrastructure {
+            logger.debug("Inserting global EMITTED event: messageId={}", messageId)
+            fluentJdbc
+                .queryOn(connection)
+                .update(
+                    "--${messageId} || ${cooperationLineage}\n" +
+                        "INSERT INTO message_event (message_id, type, cooperation_lineage, context) VALUES (:messageId, 'EMITTED', :cooperationLineage, :context)"
+                )
+                .namedParam("messageId", messageId)
+                .namedParam(
+                    "cooperationLineage",
+                    connection.createArrayOf("uuid", cooperationLineage.toTypedArray()),
+                )
+                .namedParam(
+                    "context",
+                    context?.takeIf { it.isNotEmpty() }?.let { jsonbHelper.toPGobject(it) },
+                )
+                .run()
+        }
     }
 
     /**
@@ -85,34 +88,36 @@ class MessageEventRepository(
         cooperationLineage: List<UUID>,
         context: CooperationContext?,
     ) {
-        logger.debug(
-            "Inserting scoped EMITTED event: messageId={}, coroutine='{}', step='{}'",
-            messageId,
-            coroutineName,
-            stepName,
-        )
-        fluentJdbc
-            .queryOn(connection)
-            .update(
-                """
-                INSERT INTO message_event (message_id, type, coroutine_name, coroutine_identifier, step, cooperation_lineage, context)
-                VALUES (:messageId, 'EMITTED', :coroutineName, :coroutineIdentifier, :stepName, :cooperationLineage, :context)
-                """
-                    .trimIndent()
+        asScoopInfrastructure {
+            logger.debug(
+                "Inserting scoped EMITTED event: messageId={}, coroutine='{}', step='{}'",
+                messageId,
+                coroutineName,
+                stepName,
             )
-            .namedParam("messageId", messageId)
-            .namedParam("coroutineName", coroutineName)
-            .namedParam("coroutineIdentifier", coroutineIdentifier)
-            .namedParam("stepName", stepName)
-            .namedParam(
-                "cooperationLineage",
-                connection.createArrayOf("uuid", cooperationLineage.toTypedArray()),
-            )
-            .namedParam(
-                "context",
-                context?.takeIf { it.isNotEmpty() }?.let { jsonbHelper.toPGobject(it) },
-            )
-            .run()
+            fluentJdbc
+                .queryOn(connection)
+                .update(
+                    """
+                    INSERT INTO message_event (message_id, type, coroutine_name, coroutine_identifier, step, cooperation_lineage, context)
+                    VALUES (:messageId, 'EMITTED', :coroutineName, :coroutineIdentifier, :stepName, :cooperationLineage, :context)
+                    """
+                        .trimIndent()
+                )
+                .namedParam("messageId", messageId)
+                .namedParam("coroutineName", coroutineName)
+                .namedParam("coroutineIdentifier", coroutineIdentifier)
+                .namedParam("stepName", stepName)
+                .namedParam(
+                    "cooperationLineage",
+                    connection.createArrayOf("uuid", cooperationLineage.toTypedArray()),
+                )
+                .namedParam(
+                    "context",
+                    context?.takeIf { it.isNotEmpty() }?.let { jsonbHelper.toPGobject(it) },
+                )
+                .run()
+        }
     }
 
     /**
@@ -149,59 +154,61 @@ class MessageEventRepository(
         cooperationLineage: List<UUID>,
         exception: CooperationFailure,
     ) {
-        logger.debug("Inserting ROLLBACK_EMITTED event for lineage")
-        val lineageArray = connection.createArrayOf("uuid", cooperationLineage.toTypedArray())
+        asScoopInfrastructure {
+            logger.debug("Inserting ROLLBACK_EMITTED event for lineage")
+            val lineageArray = connection.createArrayOf("uuid", cooperationLineage.toTypedArray())
 
-        fluentJdbc
-            .queryOn(connection)
-            .update(
-                """
-                WITH message_id_lookup AS (
-                    -- Find the message_id associated with this cooperation lineage
-                    -- Any event from the same lineage will have the same message_id
-                    SELECT DISTINCT message_id 
-                    FROM message_event 
-                    WHERE cooperation_lineage = :cooperationLineage
-                    LIMIT 1
+            fluentJdbc
+                .queryOn(connection)
+                .update(
+                    """
+                    WITH message_id_lookup AS (
+                        -- Find the message_id associated with this cooperation lineage
+                        -- Any event from the same lineage will have the same message_id
+                        SELECT DISTINCT message_id 
+                        FROM message_event 
+                        WHERE cooperation_lineage = :cooperationLineage
+                        LIMIT 1
+                    )
+                    INSERT INTO message_event (
+                        message_id, 
+                        type,  
+                        cooperation_lineage, 
+                        exception
+                    )
+                    SELECT 
+                        message_id_lookup.message_id, 'ROLLBACK_EMITTED', :cooperationLineage, :exception
+                    FROM message_id_lookup
+                    WHERE NOT EXISTS (
+                        -- Safety check: Only emit rollback if no part of the cooperation tree is actively running
+                        -- This includes both ancestors (parents) and descendants (children) of the scope being rolled back.
+                        -- Checking for COMMITTED and ROLLBACK_FAILED is enough because if something
+                        -- rolled back, then everything must've rolled back, and there's no point in
+                        -- emitting anything here
+                        SELECT 1
+                        FROM message_event seen
+                        LEFT JOIN message_event terminated
+                          ON terminated.cooperation_lineage = seen.cooperation_lineage
+                             AND terminated.type in ('COMMITTED', 'ROLLBACK_FAILED')
+                        WHERE seen.type = 'SEEN'                                    -- Handler started
+                          AND (
+                            -- Descendant check: our lineage is a prefix of their lineage (exclude self)
+                            (:cooperationLineage <@ seen.cooperation_lineage AND cardinality(seen.cooperation_lineage) > cardinality(:cooperationLineage))
+                            OR
+                            -- Ancestor check: their lineage is a prefix of our lineage (exclude self)
+                            (seen.cooperation_lineage <@ :cooperationLineage AND cardinality(seen.cooperation_lineage) < cardinality(:cooperationLineage))
+                          )
+                          AND terminated.cooperation_lineage IS NULL                -- But hasn't successfully completed yet
+                    )
+                    -- Prevent duplicate rollback events for the same message
+                    ON CONFLICT (message_id, type) WHERE type = 'ROLLBACK_EMITTED' DO NOTHING
+                    """
+                        .trimIndent()
                 )
-                INSERT INTO message_event (
-                    message_id, 
-                    type,  
-                    cooperation_lineage, 
-                    exception
-                )
-                SELECT 
-                    message_id_lookup.message_id, 'ROLLBACK_EMITTED', :cooperationLineage, :exception
-                FROM message_id_lookup
-                WHERE NOT EXISTS (
-                    -- Safety check: Only emit rollback if no part of the cooperation tree is actively running
-                    -- This includes both ancestors (parents) and descendants (children) of the scope being rolled back.
-                    -- Checking for COMMITTED and ROLLBACK_FAILED is enough because if something
-                    -- rolled back, then everything must've rolled back, and there's no point in
-                    -- emitting anything here
-                    SELECT 1
-                    FROM message_event seen
-                    LEFT JOIN message_event terminated
-                      ON terminated.cooperation_lineage = seen.cooperation_lineage
-                         AND terminated.type in ('COMMITTED', 'ROLLBACK_FAILED')
-                    WHERE seen.type = 'SEEN'                                    -- Handler started
-                      AND (
-                        -- Descendant check: our lineage is a prefix of their lineage (exclude self)
-                        (:cooperationLineage <@ seen.cooperation_lineage AND cardinality(seen.cooperation_lineage) > cardinality(:cooperationLineage))
-                        OR
-                        -- Ancestor check: their lineage is a prefix of our lineage (exclude self)
-                        (seen.cooperation_lineage <@ :cooperationLineage AND cardinality(seen.cooperation_lineage) < cardinality(:cooperationLineage))
-                      )
-                      AND terminated.cooperation_lineage IS NULL                -- But hasn't successfully completed yet
-                )
-                -- Prevent duplicate rollback events for the same message
-                ON CONFLICT (message_id, type) WHERE type = 'ROLLBACK_EMITTED' DO NOTHING
-                """
-                    .trimIndent()
-            )
-            .namedParam("cooperationLineage", lineageArray)
-            .namedParam("exception", jsonbHelper.toPGobject(exception))
-            .run()
+                .namedParam("cooperationLineage", lineageArray)
+                .namedParam("exception", jsonbHelper.toPGobject(exception))
+                .run()
+        }
     }
 
     /**
@@ -246,40 +253,42 @@ class MessageEventRepository(
         cooperationLineage: List<UUID>,
         exception: CooperationFailure,
     ) {
-        logger.debug("Inserting CANCELLATION_REQUESTED event")
-        val lineageArray = connection.createArrayOf("uuid", cooperationLineage.toTypedArray())
+        asScoopInfrastructure {
+            logger.debug("Inserting CANCELLATION_REQUESTED event")
+            val lineageArray = connection.createArrayOf("uuid", cooperationLineage.toTypedArray())
 
-        fluentJdbc
-            .queryOn(connection)
-            .update(
-                """
-                WITH message_id_lookup AS (
-                    SELECT DISTINCT message_id 
-                    FROM message_event 
-                    WHERE cooperation_lineage = :cooperationLineage
-                    LIMIT 1
+            fluentJdbc
+                .queryOn(connection)
+                .update(
+                    """
+                    WITH message_id_lookup AS (
+                        SELECT DISTINCT message_id
+                        FROM message_event 
+                        WHERE cooperation_lineage = :cooperationLineage
+                        LIMIT 1
+                    )
+                    INSERT INTO message_event (
+                        message_id, 
+                        type, 
+                        coroutine_name, coroutine_identifier, step, 
+                        cooperation_lineage, 
+                        exception
+                    ) 
+                    SELECT 
+                        message_id_lookup.message_id,
+                        'CANCELLATION_REQUESTED',
+                        null, null, null, 
+                        :cooperationLineage, 
+                        :exception
+                    FROM message_id_lookup
+                    ON CONFLICT (cooperation_lineage, type) WHERE type = 'CANCELLATION_REQUESTED' DO NOTHING
+                    """
+                        .trimIndent()
                 )
-                INSERT INTO message_event (
-                    message_id, 
-                    type, 
-                    coroutine_name, coroutine_identifier, step, 
-                    cooperation_lineage, 
-                    exception
-                ) 
-                SELECT 
-                    message_id_lookup.message_id,
-                    'CANCELLATION_REQUESTED',
-                    null, null, null, 
-                    :cooperationLineage, 
-                    :exception
-                FROM message_id_lookup
-                ON CONFLICT (cooperation_lineage, type) WHERE type = 'CANCELLATION_REQUESTED' DO NOTHING
-                """
-                    .trimIndent()
-            )
-            .namedParam("cooperationLineage", lineageArray)
-            .namedParam("exception", jsonbHelper.toPGobject(exception))
-            .run()
+                .namedParam("cooperationLineage", lineageArray)
+                .namedParam("exception", jsonbHelper.toPGobject(exception))
+                .run()
+        }
     }
 
     @Suppress("LongParameterList")
@@ -296,32 +305,34 @@ class MessageEventRepository(
         childFailureHandlerIteration: Int?,
         nextStep: Int?,
     ) {
-        fluentJdbc
-            .queryOn(connection)
-            .update(
-                """
-                INSERT INTO message_event (message_id, type, coroutine_name, coroutine_identifier, step, cooperation_lineage, exception, context, child_failure_handler_iteration, next_step)
-                VALUES (:messageId, :messageEventType::message_event_type, :coroutineName, :coroutineIdentifier, :stepName, :cooperationLineage, :exception, :context, :childFailureHandlerIteration, :nextStep)
-                """
-                    .trimIndent()
-            )
-            .namedParam("messageId", messageId)
-            .namedParam("messageEventType", messageEventType)
-            .namedParam("coroutineName", coroutineName)
-            .namedParam("coroutineIdentifier", coroutineIdentifier)
-            .namedParam("stepName", stepName)
-            .namedParam(
-                "cooperationLineage",
-                connection.createArrayOf("uuid", cooperationLineage.toTypedArray()),
-            )
-            .namedParam("exception", exception?.let { jsonbHelper.toPGobject(it) })
-            .namedParam(
-                "context",
-                context?.takeIf { it.isNotEmpty() }?.let { jsonbHelper.toPGobject(it) },
-            )
-            .namedParam("childFailureHandlerIteration", childFailureHandlerIteration)
-            .namedParam("nextStep", nextStep)
-            .run()
+        asScoopInfrastructure {
+            fluentJdbc
+                .queryOn(connection)
+                .update(
+                    """
+                    INSERT INTO message_event (message_id, type, coroutine_name, coroutine_identifier, step, cooperation_lineage, exception, context, child_failure_handler_iteration, next_step)
+                    VALUES (:messageId, :messageEventType::message_event_type, :coroutineName, :coroutineIdentifier, :stepName, :cooperationLineage, :exception, :context, :childFailureHandlerIteration, :nextStep)
+                    """
+                        .trimIndent()
+                )
+                .namedParam("messageId", messageId)
+                .namedParam("messageEventType", messageEventType)
+                .namedParam("coroutineName", coroutineName)
+                .namedParam("coroutineIdentifier", coroutineIdentifier)
+                .namedParam("stepName", stepName)
+                .namedParam(
+                    "cooperationLineage",
+                    connection.createArrayOf("uuid", cooperationLineage.toTypedArray()),
+                )
+                .namedParam("exception", exception?.let { jsonbHelper.toPGobject(it) })
+                .namedParam(
+                    "context",
+                    context?.takeIf { it.isNotEmpty() }?.let { jsonbHelper.toPGobject(it) },
+                )
+                .namedParam("childFailureHandlerIteration", childFailureHandlerIteration)
+                .namedParam("nextStep", nextStep)
+                .run()
+        }
     }
 
     /**
@@ -351,50 +362,52 @@ class MessageEventRepository(
         context: CooperationContext?,
         suspendedAt: Instant,
     ) {
-        val lineageArray = connection.createArrayOf("uuid", cooperationLineage.toTypedArray())
-        val suspendedAtTimestamp = java.sql.Timestamp.from(suspendedAt)
+        asScoopInfrastructure {
+            val lineageArray = connection.createArrayOf("uuid", cooperationLineage.toTypedArray())
+            val suspendedAtTimestamp = java.sql.Timestamp.from(suspendedAt)
 
-        fluentJdbc
-            .queryOn(connection)
-            .update(
-                """
-                WITH emitted_record AS (
-                    SELECT cooperation_lineage, message_id
-                    FROM message_event
-                    WHERE type = 'EMITTED'
-                        AND cooperation_lineage = :cooperationLineage
-                        AND created_at < :suspendedAt
-                        AND NOT EXISTS (
-                            SELECT 1 FROM message_event mid
-                            WHERE mid.cooperation_lineage = :cooperationLineage
-                              AND mid.type = 'SUSPENDED'
-                              AND mid.created_at > message_event.created_at
-                              AND mid.created_at < :suspendedAt
-                        )
+            fluentJdbc
+                .queryOn(connection)
+                .update(
+                    """
+                    WITH emitted_record AS (
+                        SELECT cooperation_lineage, message_id
+                        FROM message_event
+                        WHERE type = 'EMITTED'
+                            AND cooperation_lineage = :cooperationLineage
+                            AND created_at < :suspendedAt
+                            AND NOT EXISTS (
+                                SELECT 1 FROM message_event mid
+                                WHERE mid.cooperation_lineage = :cooperationLineage
+                                  AND mid.type = 'SUSPENDED'
+                                  AND mid.created_at > message_event.created_at
+                                  AND mid.created_at < :suspendedAt
+                            )
+                    )
+                    INSERT INTO message_event (
+                        message_id, type,
+                        cooperation_lineage, coroutine_name, coroutine_identifier, step,
+                        exception, context
+                    )
+                    SELECT
+                        message_id, 'ROLLBACK_EMITTED',
+                        :cooperationLineage, :coroutineName, :coroutineIdentifier, :scopeStepName, :exception, :context
+                    FROM emitted_record
+                    """
+                        .trimIndent()
                 )
-                INSERT INTO message_event (
-                    message_id, type,
-                    cooperation_lineage, coroutine_name, coroutine_identifier, step,
-                    exception, context
+                .namedParam("cooperationLineage", lineageArray)
+                .namedParam("coroutineName", coroutineName)
+                .namedParam("coroutineIdentifier", coroutineIdentifier)
+                .namedParam("scopeStepName", scopeStepName)
+                .namedParam("exception", jsonbHelper.toPGobject(exception))
+                .namedParam(
+                    "context",
+                    context?.takeIf { it.isNotEmpty() }?.let { jsonbHelper.toPGobject(it) },
                 )
-                SELECT
-                    message_id, 'ROLLBACK_EMITTED',
-                    :cooperationLineage, :coroutineName, :coroutineIdentifier, :scopeStepName, :exception, :context
-                FROM emitted_record
-                """
-                    .trimIndent()
-            )
-            .namedParam("cooperationLineage", lineageArray)
-            .namedParam("coroutineName", coroutineName)
-            .namedParam("coroutineIdentifier", coroutineIdentifier)
-            .namedParam("scopeStepName", scopeStepName)
-            .namedParam("exception", jsonbHelper.toPGobject(exception))
-            .namedParam(
-                "context",
-                context?.takeIf { it.isNotEmpty() }?.let { jsonbHelper.toPGobject(it) },
-            )
-            .namedParam("suspendedAt", suspendedAtTimestamp)
-            .run()
+                .namedParam("suspendedAt", suspendedAtTimestamp)
+                .run()
+        }
     }
 
     /**
@@ -416,7 +429,7 @@ class MessageEventRepository(
         connection: Connection,
         giveUpSqlProvider: (seenAlias: String) -> String,
         cooperationLineage: List<UUID>,
-    ): List<CooperationException> =
+    ): List<CooperationException> = asScoopInfrastructure {
         fluentJdbc
             .queryOn(connection)
             .select(
@@ -438,6 +451,7 @@ class MessageEventRepository(
                 cooperationFailure.let { CooperationFailure.Companion.toCooperationException(it) }
             }
             .filterNotNull()
+    }
 
     /**
      * Creates SEEN and ROLLING_BACK events for a given coroutine, thereby effectively starting new

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/ReturnValueRepository.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/ReturnValueRepository.kt
@@ -2,6 +2,7 @@ package io.github.gabrielshanahan.scoop.coroutine.structuredcooperation
 
 import io.github.gabrielshanahan.scoop.coroutine.Handler
 import io.github.gabrielshanahan.scoop.coroutine.VariableName
+import io.github.gabrielshanahan.scoop.coroutine.asScoopInfrastructure
 import io.github.gabrielshanahan.scoop.coroutine.handlerName
 import io.github.gabrielshanahan.scoop.coroutine.serializedValue
 import java.sql.Connection
@@ -35,38 +36,43 @@ class ReturnValueRepository(private val fluentJdbc: FluentJdbc) {
         variableName: VariableName,
         value: PGobject,
     ) {
-        val lineageArray = connection.createArrayOf("uuid", cooperationLineage.toTypedArray())
+        asScoopInfrastructure {
+            val lineageArray = connection.createArrayOf("uuid", cooperationLineage.toTypedArray())
 
-        try {
-            fluentJdbc
-                .queryOn(connection)
-                .update(
-                    """
-                    INSERT INTO return_value (cooperation_lineage, handler_name, variable_name, value)
-                    VALUES (:lineage, :handlerName, :variableName, :value)
-                    """
-                        .trimIndent()
-                )
-                .namedParam("lineage", lineageArray)
-                .namedParam("handlerName", handlerName)
-                .namedParam("variableName", variableName.serializedValue)
-                .namedParam("value", value)
-                .run()
-        } catch (e: SQLException) {
-            // Check if this is a unique constraint violation
-            if (
-                e.message?.contains("unique_return_value_per_lineage_handler_variable") == true ||
-                    e.cause
-                        ?.message
-                        ?.contains("unique_return_value_per_lineage_handler_variable") == true
-            ) {
-                throw ReturnValueAlreadyExistsException(
-                    cooperationLineage,
-                    handlerName,
-                    variableName,
-                )
+            try {
+                fluentJdbc
+                    .queryOn(connection)
+                    .update(
+                        """
+                        INSERT INTO return_value (cooperation_lineage, handler_name, variable_name, value)
+                        VALUES (:lineage, :handlerName, :variableName, :value)
+                        """
+                            .trimIndent()
+                    )
+                    .namedParam("lineage", lineageArray)
+                    .namedParam("handlerName", handlerName)
+                    .namedParam("variableName", variableName.serializedValue)
+                    .namedParam("value", value)
+                    .run()
+            } catch (e: SQLException) {
+                // Check if this is a unique constraint violation. This is a logical outcome (not an
+                // infrastructure fault), so it is rethrown as-is and passes through
+                // asScoopInfrastructure untouched.
+                if (
+                    e.message?.contains("unique_return_value_per_lineage_handler_variable") ==
+                        true ||
+                        e.cause
+                            ?.message
+                            ?.contains("unique_return_value_per_lineage_handler_variable") == true
+                ) {
+                    throw ReturnValueAlreadyExistsException(
+                        cooperationLineage,
+                        handlerName,
+                        variableName,
+                    )
+                }
+                throw e
             }
-            throw e
         }
     }
 
@@ -87,11 +93,11 @@ class ReturnValueRepository(private val fluentJdbc: FluentJdbc) {
         parentLineage: List<UUID>,
         variableName: VariableName,
         handlerRegistry: (String) -> Handler<*>,
-    ): Map<Handler<*>, PGobject> {
+    ): Map<Handler<*>, PGobject> = asScoopInfrastructure {
         val lineageArray = connection.createArrayOf("uuid", parentLineage.toTypedArray())
         val childCardinality = parentLineage.size + 1
 
-        return fluentJdbc
+        fluentJdbc
             .queryOn(connection)
             .select(
                 """
@@ -127,11 +133,11 @@ class ReturnValueRepository(private val fluentJdbc: FluentJdbc) {
         parentLineage: List<UUID>,
         variableName: VariableName,
         handler: Handler<*>,
-    ): PGobject? {
+    ): PGobject? = asScoopInfrastructure {
         val lineageArray = connection.createArrayOf("uuid", parentLineage.toTypedArray())
         val childCardinality = parentLineage.size + 1
 
-        return fluentJdbc
+        fluentJdbc
             .queryOn(connection)
             .select(
                 """

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/MessageRepository.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/MessageRepository.kt
@@ -1,5 +1,6 @@
 package io.github.gabrielshanahan.scoop.messaging
 
+import io.github.gabrielshanahan.scoop.coroutine.asScoopInfrastructure
 import java.sql.Connection
 import java.time.ZoneOffset
 import java.util.UUID
@@ -80,7 +81,7 @@ class MessageRepository(private val fluentJdbc: FluentJdbc) {
      * - **Exception Propagation**: Message details included in distributed stack traces
      * - **Cooperation Lineage**: Message IDs link parent-child relationships in lineage hierarchy
      */
-    fun fetchMessage(connection: Connection, messageId: UUID): Message? =
+    fun fetchMessage(connection: Connection, messageId: UUID): Message? = asScoopInfrastructure {
         fluentJdbc
             .queryOn(connection)
             .select("SELECT id, topic, payload, created_at FROM message WHERE id = :messageId")
@@ -99,6 +100,7 @@ class MessageRepository(private val fluentJdbc: FluentJdbc) {
             }
             .orElse(null)
             .also { if (it == null) logger.debug("Message not found: id={}", messageId) }
+    }
 
     /**
      * Persists a new message to the message table and returns the complete message with generated
@@ -130,25 +132,27 @@ class MessageRepository(private val fluentJdbc: FluentJdbc) {
      * @throws RuntimeException if message insertion fails (wraps database exceptions)
      */
     fun insertMessage(connection: Connection, topic: String, payload: PGobject): Message =
-        // For PostgreSQL RETURNING clause, we need to use a regular fluentJdbc.select() query
-        fluentJdbc
-            .queryOn(connection)
-            .select(
-                "INSERT INTO message (topic, payload) VALUES (:topic, :payload) RETURNING id, created_at"
-            )
-            .namedParam("topic", topic)
-            .namedParam("payload", payload)
-            .singleResult { resultSet ->
-                Message(
-                    id = resultSet.getObject("id", UUID::class.java),
-                    topic = topic,
-                    payload = payload,
-                    createdAt =
-                        resultSet
-                            .getTimestamp("created_at")
-                            .toLocalDateTime()
-                            .atOffset(ZoneOffset.UTC),
+        asScoopInfrastructure {
+            // For PostgreSQL RETURNING clause, we need to use a regular fluentJdbc.select() query
+            fluentJdbc
+                .queryOn(connection)
+                .select(
+                    "INSERT INTO message (topic, payload) VALUES (:topic, :payload) RETURNING id, created_at"
                 )
-            }
-            .also { logger.debug("Inserted message: id={}, topic='{}'", it.id, topic) }
+                .namedParam("topic", topic)
+                .namedParam("payload", payload)
+                .singleResult { resultSet ->
+                    Message(
+                        id = resultSet.getObject("id", UUID::class.java),
+                        topic = topic,
+                        payload = payload,
+                        createdAt =
+                            resultSet
+                                .getTimestamp("created_at")
+                                .toLocalDateTime()
+                                .atOffset(ZoneOffset.UTC),
+                    )
+                }
+                .also { logger.debug("Inserted message: id={}, topic='{}'", it.id, topic) }
+        }
 }

--- a/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/ScoopProducer.kt
+++ b/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/ScoopProducer.kt
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty
  * dependencies (FluentJdbc, ObjectMapper, PgSubscriber).
  */
 @ApplicationScoped
+@Suppress("LongParameterList")
 class ScoopProducer(
     private val fluentJdbc: FluentJdbc,
     private val objectMapper: ObjectMapper,
@@ -35,6 +36,17 @@ class ScoopProducer(
     private val dataSource: DataSource,
     @ConfigProperty(name = "scoop.tick-interval-ms", defaultValue = "50")
     private val tickIntervalMs: Long,
+    // Exponential backoff between retries after a ScoopInfrastructureException (Scoop's own
+    // bookkeeping failed, e.g. a dead connection — never a saga-logic failure, so never a
+    // rollback).
+    // Default "0s" base = retry on the very next tick (no backoff). Set a base (and a cap) to
+    // spread
+    // retries out as base * 2^(attempt-1), capped at the max, so a persistently-dead connection is
+    // not hammered every tick.
+    @ConfigProperty(name = "scoop.retry.infra-backoff-base", defaultValue = "0s")
+    private val retryBackoffBase: Duration,
+    @ConfigProperty(name = "scoop.retry.infra-backoff-max", defaultValue = "0s")
+    private val retryBackoffMax: Duration,
 ) {
 
     @Produces @ApplicationScoped fun jsonbHelper(): JsonbHelper = JsonbHelper(objectMapper)
@@ -97,6 +109,8 @@ class ScoopProducer(
             scopeCapabilities,
             jsonbHelper,
             transactionRunner,
+            retryBackoffBase = retryBackoffBase,
+            retryBackoffMax = retryBackoffMax,
         )
 
     @Produces

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/InfrastructureFailureRetryTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/InfrastructureFailureRetryTest.kt
@@ -1,0 +1,141 @@
+package io.github.gabrielshanahan.scoop.coroutine.structuredcooperation
+
+import io.github.gabrielshanahan.scoop.coroutine.ScoopInfrastructureException
+import io.github.gabrielshanahan.scoop.coroutine.StructuredCooperationTest
+import io.github.gabrielshanahan.scoop.coroutine.builder.saga
+import io.github.gabrielshanahan.scoop.coroutine.ciSleep
+import io.github.gabrielshanahan.scoop.coroutine.getEventSequence
+import io.github.gabrielshanahan.scoop.messaging.eventLoopStrategy
+import io.github.gabrielshanahan.scoop.transactional
+import io.quarkus.test.junit.QuarkusTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Covers the core property that keeps perpetual sagas alive across transient infrastructure faults:
+ * a [ScoopInfrastructureException] raised while a step is being processed (Scoop's own bookkeeping
+ * failing — e.g. a dead JDBC connection) must NOT roll the saga back. The run is left at its last
+ * committed step and retried on a later tick. A plain business exception, by contrast, must still
+ * roll back exactly as before.
+ *
+ * The infrastructure failure is simulated by throwing [ScoopInfrastructureException] from the step
+ * body: the event loop funnels both a step throw and Scoop's own bookkeeping throw through the same
+ * classification point
+ * ([io.github.gabrielshanahan.scoop.coroutine.continuation.BaseCooperationContinuation.resumeCoroutine]),
+ * so throwing it from the step exercises exactly that seam.
+ */
+/** A named business exception so the "still rolls back" test does not throw a generic one. */
+private class SimulatedBusinessFailure(message: String) : RuntimeException(message)
+
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class InfrastructureFailureRetryTest : StructuredCooperationTest() {
+
+    @Test
+    fun `a ScoopInfrastructureException is retried (not rolled back) and the run eventually commits`() {
+        val attempts = AtomicInteger(0)
+        val committed = CountDownLatch(1)
+
+        val rootHandler = "root-handler"
+        val rootSubscription =
+            messageQueue.subscribe(
+                rootTopic,
+                saga(rootHandler, handlerRegistry.eventLoopStrategy()) {
+                    step { _, _ ->
+                        val attempt = attempts.incrementAndGet()
+                        // Fail the first two attempts the way a dead connection would, then
+                        // succeed.
+                        if (attempt < 3) {
+                            throw ScoopInfrastructureException(
+                                RuntimeException("simulated dead connection #$attempt")
+                            )
+                        }
+                        committed.countDown()
+                    }
+                },
+            )
+
+        try {
+            val rootPayload = jsonbHelper.toPGobject(mapOf("initial" to "true"))
+            fluentJdbc.transactional { connection ->
+                messageQueue.launch(connection, rootTopic, rootPayload)
+            }
+
+            Assertions.assertTrue(
+                committed.await(20, TimeUnit.SECONDS),
+                "the run should eventually succeed by retrying",
+            )
+            ciSleep(500)
+
+            // Two transient failures, then a success.
+            Assertions.assertEquals(3, attempts.get())
+
+            val types = fluentJdbc.getEventSequence().map { it.first }
+            Assertions.assertFalse(
+                types.contains("ROLLING_BACK"),
+                "an infrastructure failure must never enter ROLLING_BACK: $types",
+            )
+            Assertions.assertFalse(
+                types.contains("ROLLED_BACK"),
+                "an infrastructure failure must never roll back: $types",
+            )
+            Assertions.assertTrue(
+                types.contains("COMMITTED"),
+                "the run should commit after a successful retry: $types",
+            )
+        } finally {
+            rootSubscription.close()
+        }
+    }
+
+    @Test
+    fun `a plain business exception still rolls back and is not retried`() {
+        val attempts = AtomicInteger(0)
+
+        val rootHandler = "root-handler"
+        val rootSubscription =
+            messageQueue.subscribe(
+                rootTopic,
+                saga(rootHandler, handlerRegistry.eventLoopStrategy()) {
+                    step { _, _ ->
+                        attempts.incrementAndGet()
+                        throw SimulatedBusinessFailure("business failure")
+                    }
+                },
+            )
+
+        try {
+            val rootPayload = jsonbHelper.toPGobject(mapOf("initial" to "true"))
+            fluentJdbc.transactional { connection ->
+                messageQueue.launch(connection, rootTopic, rootPayload)
+            }
+
+            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15)
+            while (
+                System.nanoTime() < deadline &&
+                    fluentJdbc.getEventSequence().none { it.first == "ROLLED_BACK" }
+            ) {
+                ciSleep(200)
+            }
+            ciSleep(500)
+
+            val types = fluentJdbc.getEventSequence().map { it.first }
+            Assertions.assertTrue(
+                types.contains("ROLLING_BACK"),
+                "a business failure should enter ROLLING_BACK: $types",
+            )
+            Assertions.assertTrue(
+                types.contains("ROLLED_BACK"),
+                "a business failure should roll back: $types",
+            )
+            // A business failure is not retried — the step ran exactly once.
+            Assertions.assertEquals(1, attempts.get())
+        } finally {
+            rootSubscription.close()
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A transient failure of Scoop's **own** persistence — most often a dead/idle-closed JDBC connection used during `giveUpIfNecessary` or an emission write — was indistinguishable from a saga-logic failure. Any exception thrown while processing a step became a `ContinuationResult.Failure` and drove the saga into `ROLLING_BACK`. For a **perpetual** (infinite-`GoTo`) saga that unwinds the *entire* accumulated loop history and kills the loop for good.

Real-world incident: an overnight connection blip put a fleet of perpetual ingestor loops into terminal `ROLLED_BACK` / `ROLLBACK_FAILED`; they never recovered, even across restarts.

## Fix

The governing principle: **only a failure of the saga-defining code (`invoke` / `rollback` / `handleChildFailures`) should drive rollback. A failure of Scoop's own machinery must not.**

- New `ScoopInfrastructureException`, applied at the **repository boundary** (`MessageEventRepository`, `MessageRepository`, `ReturnValueRepository`) via `asScoopInfrastructure { }`. Deliberate logical signals (`ReturnValueAlreadyExistsException`, the `ScoopException` control signals) pass through; `Error`s (OOM, …) are **never** caught and propagate untouched.
  - The two ~200-line read-queries (`startContinuationsForCoroutine`, `fetchPendingCoroutineRun`) are *not* wrapped: they run during tick setup, before step resumption, and already fail the tick safely without reaching the rollback path.
- `BaseCooperationContinuation.resumeCoroutine` rethrows a `ScoopInfrastructureException` instead of turning it into a `Failure`.
- The `EventLoop` treats it as a transient tick failure: the tick's transaction rolls back and the run is re-resumed from its last committed step on a later tick — never rolled back.

## Backoff knobs

Retries happen on the **next tick by default** (no behavioural change). Two opt-in properties add exponential backoff (`base * 2^(attempt-1)`, capped) so a persistently-dead connection isn't hammered:

- `scoop.retry.infra-backoff-base` (default `0s`)
- `scoop.retry.infra-backoff-max` (default `0s`)

## Tests

`InfrastructureFailureRetryTest`: a `ScoopInfrastructureException` during step processing retries to `COMMITTED` with no `ROLLING_BACK`; a plain business exception still rolls back and is not retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)