### PR TITLE
feat(eventloop): reconcile on demand instead of every tick

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Changed
+
+- **Reconciliation now runs on demand instead of on every tick.** The first half of each event-loop tick — `startContinuationsForCoroutine`, the `EMITTED→SEEN` / `ROLLBACK_EMITTED→ROLLING_BACK` anti-joins over `message_event` — used to run on *every* tick of *every* subscribed worker, whether or not anything had been emitted. With N idle topics at a fast tick interval this was the dominant idle cost (on one ~48-topic deployment at a 500 ms tick it was ~58% of a fully-utilised core doing nothing). Reconciliation is now gated on a per-worker signal set by the same `LISTEN/NOTIFY` that already wakes the loop: a worker reconciles only after a notification for its topic (and drains across a few ticks so contending siblings all start — see below), plus a rare safety-net sweep. Idle topics now do ~zero reconciliation scans. **The resume half of the tick is unchanged — it still runs every tick**, so time-based resumption (e.g. deadlines/sleep) and recovery from a missed notification are unaffected. No application code changes are required to benefit. **Adopters running multiple *distinct* sagas on the *same* topic in one JVM** previously relied on every-tick reconciliation to start the overwritten ones (a Vert.x `PgChannel` has a single handler slot); this is now handled correctly by the notifier itself (see *Fixed*), but it means you should be on this version before reducing your tick frequency.
+
+### Added
+
+- **`scoop.reconcile.safety-net-interval`** (default `30s`): the upper bound on how stale a worker's reconciliation may get when no `NOTIFY` arrives. This is the worst-case recovery latency for any *missed* notification — a dropped `LISTEN` connection, a server crash that wipes the async-notify queue, or a row left under `FOR UPDATE SKIP LOCKED` contention longer than the on-demand drain tail. It preserves Scoop's "correct without `LISTEN/NOTIFY` at all" guarantee while making the common idle path free. Lower it to tighten worst-case recovery at the cost of more idle reconciliation scans; the default is well above any tick interval. Correctness never depends on notification delivery — only latency does.
+- **Migration `V5__notify_on_rollback_emitted.sql`** (applied automatically by the bundled Flyway migrations): a trigger that fires `pg_notify(topic, message_id)` when a `ROLLBACK_EMITTED` `message_event` is inserted. Ordinary emissions already notify via the `message` insert trigger, but a `ROLLBACK_EMITTED` reuses an existing message id and inserts no `message` row, so it fired no notification. Without it, gated reconciliation would only pick up rollbacks on the safety-net sweep; with it, rollback start stays prompt and event-driven, symmetric with ordinary emissions. **Adopters must apply this migration** (it ships in `scoop-quarkus`'s `db/migration` and runs on startup if you use the provided Flyway setup; otherwise apply the equivalent trigger to your schema).
+
+### Fixed
+
+- **A single `NOTIFY` now starts *all* handlers subscribed to a topic, not just the last one registered in a JVM.** `PgSubscriberTopicNotifier` registered one Vert.x channel handler per `onMessage` call, but a Vert.x `PgChannel` has a single handler slot and `channel(name)` is shared per name, so the last subscriber to a topic silently overwrote earlier ones' notification handlers. This was masked while reconciliation ran every tick; with on-demand reconciliation an overwritten handler would have started only on the safety-net sweep. The notifier now owns the fan-out — one Vert.x handler per topic dispatching to every registered callback — so every worker/saga on a topic is woken by each notification.
+
 ## v0.3.2 — 2026-06-20
 
 ## v0.3.1 — 2026-06-19

--- a/config/detekt/baseline-scoop-core.xml
+++ b/config/detekt/baseline-scoop-core.xml
@@ -2,7 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>LongMethod:MessageEventRepository.kt:MessageEventRepository$fun startContinuationsForCoroutine</ID>
+    <ID>LongMethod:MessageEventRepository.kt:MessageEventRepository$fun startContinuationsForCoroutine: Int</ID>
     <ID>LongMethod:PendingCoroutineRunSql.kt:fun candidateSeensWaitingToBeProcessed</ID>
     <ID>LongMethod:PendingCoroutineRunSql.kt:fun finalSelect</ID>
     <ID>LongMethod:RollbackPathContinuation.kt:internal fun DistributedCoroutine.buildRollbackPathContinuation: RollbackPathContinuation</ID>

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/EventLoop.kt
@@ -48,6 +48,19 @@ private const val SHUTDOWN_TIMEOUT_SECONDS = 10L
 private const val SHUTDOWN_INTERRUPT_TIMEOUT_SECONDS = 2L
 
 /**
+ * Default upper bound on how stale a worker's reconciliation may get when no NOTIFY arrives. Acts
+ * as the safety-net sweep interval in [ReconcileGate]: it is the worst-case recovery latency for
+ * any missed notification (dropped LISTEN, server crash wiping the async-notify queue, a `SKIP
+ * LOCKED` row skipped under contention, the subscribe/LISTEN startup window). Well above any tick
+ * interval, so idle topics reconcile rarely; lower it to tighten worst-case recovery at the cost of
+ * more idle reconciles. Overridable via `scoop.reconcile.safety-net-interval`.
+ */
+private const val DEFAULT_RECONCILE_SAFETY_NET_SECONDS = 30L
+
+val DEFAULT_RECONCILE_SAFETY_NET: Duration =
+    Duration.ofSeconds(DEFAULT_RECONCILE_SAFETY_NET_SECONDS)
+
+/**
  * The core execution engine that drives structured cooperation by resuming suspended sagas.
  *
  * The [EventLoop] is the heart of Scoop's execution model. It implements the "event loop" pattern
@@ -170,23 +183,43 @@ class EventLoop(
     fun tick(
         topic: String,
         distributedCoroutine: DistributedCoroutine,
+        reconcileGate: ReconcileGate = ReconcileGate.ALWAYS,
         isShuttingDown: () -> Boolean = { false },
     ) {
         try {
-            fluentJdbc.transactional { connection ->
+            // Reconciliation (EMITTED→SEEN / ROLLBACK_EMITTED→ROLLING_BACK) only has work to do on
+            // a
+            // tick that follows a NOTIFY for this topic; on an idle safety-net tick the anti-joins
+            // are guaranteed empty. The gate skips them unless a notification has been coalesced
+            // since the last reconcile (or the safety-net interval elapsed). The resume drain below
+            // always runs — time-based resume, child-completion and missed-NOTIFY recovery need it
+            // every tick. See [ReconcileGate].
+            if (reconcileGate.shouldReconcile()) {
                 try {
-                    messageEventRepository.startContinuationsForCoroutine(
-                        connection,
-                        distributedCoroutine.identifier.name,
-                        distributedCoroutine.identifier.instance,
-                        topic,
-                        distributedCoroutine.eventLoopStrategy,
-                    )
+                    val insertedRows = fluentJdbc.transactional { connection ->
+                        try {
+                            messageEventRepository.startContinuationsForCoroutine(
+                                connection,
+                                distributedCoroutine.identifier.name,
+                                distributedCoroutine.identifier.instance,
+                                topic,
+                                distributedCoroutine.eventLoopStrategy,
+                            )
+                        } catch (e: Exception) {
+                            logger.error(
+                                "[${connection.backendPID()}] Error when starting continuations for coroutine ${distributedCoroutine.identifier}",
+                                e,
+                            )
+                            throw e
+                        }
+                    }
+                    reconcileGate.reconcileSucceeded(insertedRows)
                 } catch (e: Exception) {
-                    logger.error(
-                        "[${connection.backendPID()}] Error when starting continuations for coroutine ${distributedCoroutine.identifier}",
-                        e,
-                    )
+                    // Re-arm so a failed/rolled-back reconcile is retried on the next tick instead
+                    // of
+                    // waiting for the safety-net sweep, then propagate (preserving the prior
+                    // behaviour of aborting this tick before the drain).
+                    reconcileGate.reconcileFailed()
                     throw e
                 }
             }
@@ -280,6 +313,7 @@ class EventLoop(
         topic: String,
         distributedCoroutine: DistributedCoroutine,
         runApproximatelyEvery: Duration,
+        reconcileSafetyNet: Duration = DEFAULT_RECONCILE_SAFETY_NET,
         isShuttingDown: () -> Boolean = { false },
     ): PeriodicTick {
         val executor = Executors.newSingleThreadScheduledExecutor { r ->
@@ -287,6 +321,11 @@ class EventLoop(
         }
         val intervalMs = runApproximatelyEvery.toMillis()
         val jitterMs = (intervalMs * 0.02).toLong()
+
+        // Per-worker reconciliation gate. Set dirty by [PeriodicTick.trigger] on every NOTIFY (even
+        // a
+        // coalesced one), consumed by [tick]. See [ReconcileGate].
+        val reconcileGate = ReconcileGate.create(reconcileSafetyNet)
 
         // One permit represents "there is at most one tick accounted for — running or queued."
         // Both the scheduled path and [trigger] try-acquire *before* enqueuing and release once the
@@ -301,7 +340,7 @@ class EventLoop(
                 logger.debug(
                     "Starting tick for topic $topic and coroutine ${distributedCoroutine.identifier}"
                 )
-                tick(topic, distributedCoroutine, isShuttingDown)
+                tick(topic, distributedCoroutine, reconcileGate, isShuttingDown)
             } catch (e: Exception) {
                 logger.error("Event loop for ${distributedCoroutine.identifier} failed", e)
             } finally {
@@ -330,6 +369,14 @@ class EventLoop(
 
         return object : PeriodicTick {
             override fun trigger() {
+                // Mark dirty *unconditionally, before* the acquire below: a trigger that is
+                // coalesced
+                // (because a tick is already pending/running) must still record that there may be
+                // new
+                // work, otherwise the notification it represents would be lost — the in-flight tick
+                // may already have consumed its dirty bit. Whichever tick runs next then
+                // reconciles.
+                reconcileGate.markDirty()
                 // Acquire first, enqueue second: if another tick is already pending or running,
                 // we drop this trigger entirely rather than piling up no-op runnables on the
                 // executor's queue. The permit is released by `runTick` or the catch branch below.

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/ReconcileGate.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/ReconcileGate.kt
@@ -1,0 +1,145 @@
+package io.github.gabrielshanahan.scoop.coroutine
+
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Decides, per worker, whether a given [tick][EventLoop.tick] should run the
+ * [reconciliation][io.github.gabrielshanahan.scoop.coroutine.structuredcooperation.MessageEventRepository.startContinuationsForCoroutine]
+ * step (the EMITTED→SEEN / ROLLBACK_EMITTED→ROLLING_BACK anti-joins over `message_event`).
+ *
+ * ## Why this exists
+ *
+ * Reconciliation only has work to do when a new `EMITTED` or `ROLLBACK_EMITTED` row appeared on
+ * this worker's topic. Every such row is accompanied by a Postgres `NOTIFY` (the `message` insert
+ * trigger for `EMITTED`, and the `ROLLBACK_EMITTED` insert trigger added in `V5`), which is bridged
+ * to [PeriodicTick.trigger][PeriodicTick.trigger]. On a purely periodic "safety-net" tick with no
+ * intervening notification, the anti-joins are guaranteed empty — running them is pure waste. With
+ * N idle subscribed topics that waste is ~2 `message_event` scans per topic per tick, forever.
+ *
+ * This gate turns reconciliation from "every tick" into "only when a notification says there might
+ * be work, plus a rare safety sweep".
+ *
+ * ## Drain, don't reconcile-once
+ *
+ * A single notification can require **several** reconcile passes to fully drain, because sibling
+ * handlers reconciling messages under the **same** parent contend on that parent's `SEEN` row via
+ * `FOR UPDATE SKIP LOCKED`: on a contended pass the loser inserts nothing and must retry once the
+ * winner releases the lock. Reconciling exactly once per notification would strand the loser until
+ * the safety-net sweep (tens of seconds). So once woken, the gate keeps reconciling every tick
+ * until it observes [QUIET_TICKS] **consecutive** passes that inserted nothing — any productive
+ * pass resets the counter, so an arbitrary fan-out of contending siblings drains in order. After
+ * the tail goes quiet the worker stops reconciling (idle topics cost ~zero) until the next
+ * notification or safety sweep.
+ *
+ * ## Safety net
+ *
+ * Independently of notifications, a reconcile is forced at least every [forceReconcileEvery]. This
+ * preserves Scoop's "correct without LISTEN/NOTIFY at all" guarantee: even if every notification
+ * were lost (dropped LISTEN, server crash wiping the async-notify queue, a row skipped under
+ * contention for longer than the quiet tail), reconciliation still runs within that interval —
+ * correctness never depends on notification delivery, only latency does.
+ *
+ * ## Concurrency
+ *
+ * [markDirty] is called from the NOTIFY callback thread (a virtual thread, see
+ * [io.github.gabrielshanahan.scoop.messaging.TopicNotifier]); every other method runs on the
+ * worker's single-thread tick executor. Only [dirtySignal] crosses threads, so it is the lone
+ * [AtomicBoolean]; [quietTicksRemaining] and [nextSweepNanos] are touched solely by the executor
+ * thread.
+ *
+ * The critical ordering is **consume-before-work**: [shouldReconcile] clears the signal *before*
+ * the reconcile transaction opens its snapshot, so a notification landing *during* the reconcile
+ * re-arms the gate and is honoured on the next tick rather than being silently cleared after the
+ * fact (a notification always fires *after* its row commits; the clear happens *before* the
+ * subsequent snapshot, so any signal a tick consumes corresponds to a row that tick will see).
+ */
+class ReconcileGate private constructor(private val intervalNanos: Long, seedNanos: Long) {
+
+    // Set by NOTIFY (any thread), consumed by the executor in shouldReconcile. Starts armed so the
+    // first tick after subscribe/startup reconciles, catching messages emitted while this worker
+    // was
+    // down.
+    private val dirtySignal = AtomicBoolean(true)
+
+    // Remaining ticks to keep reconciling before going idle; reset whenever a notification arrives
+    // or
+    // a reconcile pass is productive. Executor-thread-only.
+    private var quietTicksRemaining = QUIET_TICKS
+
+    // Monotonic (wall-clock-independent) instant of the next forced safety-net reconcile.
+    @Volatile private var nextSweepNanos: Long = seedNanos
+
+    /**
+     * Records that a notification arrived for this worker's topic. Safe to call from any thread.
+     */
+    fun markDirty() {
+        dirtySignal.set(true)
+    }
+
+    /**
+     * Returns whether this tick should reconcile, atomically consuming the dirty signal. A gate
+     * built with a non-positive interval ([ALWAYS]) never gates — it reconciles every tick,
+     * preserving the pre-gating behaviour for direct [EventLoop.tick] callers (e.g. tests).
+     */
+    fun shouldReconcile(nowNanos: Long = System.nanoTime()): Boolean {
+        if (intervalNanos <= 0L) return true
+        if (dirtySignal.getAndSet(false)) {
+            quietTicksRemaining = QUIET_TICKS
+        }
+        // Subtraction compare is immune to nanoTime() wraparound (its value is meaningful only as a
+        // difference).
+        return quietTicksRemaining > 0 || nowNanos - nextSweepNanos >= 0L
+    }
+
+    /**
+     * Records the outcome of a committed reconcile pass and pushes the safety-net timer forward. A
+     * pass that inserted rows keeps the drain going (more contending work may remain); a pass that
+     * inserted nothing counts towards the quiet tail.
+     */
+    fun reconcileSucceeded(insertedRows: Int, nowNanos: Long = System.nanoTime()) {
+        if (intervalNanos <= 0L) return
+        quietTicksRemaining =
+            if (insertedRows > 0) QUIET_TICKS else (quietTicksRemaining - 1).coerceAtLeast(0)
+        nextSweepNanos = nowNanos + intervalNanos
+    }
+
+    /** Keeps the drain armed so a failed/rolled-back reconcile is retried on the next tick. */
+    fun reconcileFailed() {
+        if (intervalNanos > 0L) {
+            quietTicksRemaining = QUIET_TICKS
+        }
+    }
+
+    companion object {
+        /**
+         * Consecutive zero-insert reconcile passes required before a woken worker stops
+         * reconciling. Sized to absorb transient `FOR UPDATE SKIP LOCKED` contention on a parent
+         * SEEN row (each contended sibling resolves within a tick or two); the safety net covers
+         * anything longer.
+         */
+        private const val QUIET_TICKS = 3
+
+        /** A non-gating gate: always reconciles. Default for direct [EventLoop.tick] callers. */
+        val ALWAYS = ReconcileGate(0L, 0L)
+
+        /**
+         * Builds a per-worker gate that forces a reconcile at least every [forceReconcileEvery].
+         * The first sweep is seeded with a random offset in `[0, forceReconcileEvery)` so that many
+         * workers booted together do not all sweep on the same cadence (which would produce a
+         * synchronized reconcile herd across the fleet).
+         */
+        fun create(
+            forceReconcileEvery: Duration,
+            nowNanos: Long = System.nanoTime(),
+        ): ReconcileGate {
+            val intervalNanos = forceReconcileEvery.toNanos()
+            if (intervalNanos <= 0L) return ALWAYS
+            @Suppress(
+                "InsecureRandom"
+            ) // not security-sensitive: only spreads safety sweeps in time
+            val jitterNanos = (Math.random() * intervalNanos).toLong()
+            return ReconcileGate(intervalNanos, nowNanos + jitterNanos)
+        }
+    }
+}

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/MessageEventRepository.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/coroutine/structuredcooperation/MessageEventRepository.kt
@@ -518,7 +518,7 @@ class MessageEventRepository(
         coroutineIdentifier: String,
         topic: String,
         eventLoopStrategy: EventLoopStrategy,
-    ) {
+    ): Int {
         logger.debug("Starting continuations: coroutine='{}', topic='{}'", coroutineName, topic)
         @Language("PostgreSQL")
         val sql =
@@ -654,18 +654,24 @@ class MessageEventRepository(
                     ON CONFLICT (coroutine_name, message_id, type) WHERE type = 'ROLLING_BACK' DO NOTHING
                     RETURNING id
                 )
-                -- Just here to execute the CTEs
-                SELECT 1;
+                -- Report how many rows were actually inserted. The caller's reconciliation gate
+                -- uses this to keep reconciling across ticks until a pass drains (inserts nothing):
+                -- a single NOTIFY can require several passes when sibling handlers contend on the
+                -- same parent SEEN row via FOR UPDATE SKIP LOCKED (the loser inserts nothing on the
+                -- contended pass and must retry once the lock is released).
+                SELECT
+                    (SELECT count(*) FROM seen_insert)
+                    + (SELECT count(*) FROM rolling_back_insert) AS inserted;
             """
                 .trimIndent()
 
-        fluentJdbc
+        return fluentJdbc
             .queryOn(connection)
             .select(sql)
             .namedParam("coroutine_name", coroutineName)
             .namedParam("coroutine_identifier", coroutineIdentifier)
             .namedParam("topic", topic)
-            .singleResult {}
+            .singleResult { it.getInt("inserted") }
     }
 
     /**

--- a/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
+++ b/scoop-core/src/main/kotlin/io/github/gabrielshanahan/scoop/messaging/PostgresMessageQueue.kt
@@ -1,6 +1,7 @@
 package io.github.gabrielshanahan.scoop.messaging
 
 import io.github.gabrielshanahan.scoop.JsonbHelper
+import io.github.gabrielshanahan.scoop.coroutine.DEFAULT_RECONCILE_SAFETY_NET
 import io.github.gabrielshanahan.scoop.coroutine.DistributedCoroutine
 import io.github.gabrielshanahan.scoop.coroutine.DistributedCoroutineIdentifier
 import io.github.gabrielshanahan.scoop.coroutine.EventLoop
@@ -43,6 +44,7 @@ class PostgresMessageQueue(
     private val messageRepository: MessageRepository,
     private val eventLoop: EventLoop,
     private val tickInterval: Duration = DEFAULT_TICK_INTERVAL,
+    private val reconcileSafetyNet: Duration = DEFAULT_RECONCILE_SAFETY_NET,
 ) : HandlerRegistry, AutoCloseable {
 
     private val topicsToCoroutines =
@@ -174,6 +176,7 @@ class PostgresMessageQueue(
                     topic,
                     workerSaga,
                     tickInterval,
+                    reconcileSafetyNet,
                     isShuttingDown = { shuttingDown.get() || ticksPaused.get() },
                 )
             // Route the NOTIFY callback through the worker's own single-thread executor so

--- a/scoop-core/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/ReconcileGateTest.kt
+++ b/scoop-core/src/test/kotlin/io/github/gabrielshanahan/scoop/coroutine/ReconcileGateTest.kt
@@ -1,0 +1,113 @@
+package io.github.gabrielshanahan.scoop.coroutine
+
+import java.time.Duration
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ReconcileGateTest {
+
+    private val intervalSeconds = 30L
+
+    // A gate driven by an explicit monotonic clock so the safety-net timing is deterministic.
+    private fun gate(startNanos: Long = 0L): ReconcileGate =
+        ReconcileGate.create(Duration.ofSeconds(intervalSeconds), nowNanos = startNanos)
+
+    private val Int.secondsAsNanos: Long
+        get() = Duration.ofSeconds(this.toLong()).toNanos()
+
+    // Reconcile (consume + run + commit an empty pass) until the gate goes idle, returning how many
+    // passes ran. Bounded so a never-quiescing gate fails the test instead of looping forever.
+    private fun drainUntilIdle(g: ReconcileGate, nowNanos: Long): Int {
+        var passes = 0
+        while (g.shouldReconcile(nowNanos)) {
+            g.reconcileSucceeded(insertedRows = 0, nowNanos = nowNanos)
+            passes++
+            check(passes < 100) { "gate never went idle" }
+        }
+        return passes
+    }
+
+    @Test
+    fun `ALWAYS always reconciles regardless of state`() {
+        val g = ReconcileGate.ALWAYS
+        assertTrue(g.shouldReconcile())
+        g.reconcileSucceeded(insertedRows = 0)
+        assertTrue(g.shouldReconcile(), "ALWAYS never gates")
+    }
+
+    @Test
+    fun `starts armed so the first tick reconciles, then drains to idle`() {
+        val g = gate()
+        // Fresh gate is armed; it drains a short quiet tail of empty passes then goes idle.
+        val passes = drainUntilIdle(g, nowNanos = 0L)
+        assertTrue(passes in 1..10, "should reconcile a small bounded tail, was $passes")
+        assertFalse(g.shouldReconcile(nowNanos = 1.secondsAsNanos), "idle after the tail")
+    }
+
+    @Test
+    fun `markDirty re-arms the drain`() {
+        val g = gate()
+        drainUntilIdle(g, nowNanos = 0L)
+        assertFalse(g.shouldReconcile(nowNanos = 1.secondsAsNanos))
+        g.markDirty()
+        assertTrue(
+            g.shouldReconcile(nowNanos = 1.secondsAsNanos),
+            "a notification re-arms the gate",
+        )
+    }
+
+    @Test
+    fun `a productive pass keeps the drain going (handles contending siblings)`() {
+        val g = gate()
+        drainUntilIdle(g, nowNanos = 0L)
+        g.markDirty()
+        // First pass after the notification inserts nothing (e.g. it lost a SKIP LOCKED race)...
+        assertTrue(g.shouldReconcile(nowNanos = 1.secondsAsNanos))
+        g.reconcileSucceeded(insertedRows = 0, nowNanos = 1.secondsAsNanos)
+        // ...next pass wins the lock and inserts a row, which must reset the tail so further
+        // contending work still gets drained.
+        assertTrue(g.shouldReconcile(nowNanos = 1.secondsAsNanos))
+        g.reconcileSucceeded(insertedRows = 1, nowNanos = 1.secondsAsNanos)
+        assertTrue(
+            g.shouldReconcile(nowNanos = 1.secondsAsNanos),
+            "productive pass resets the tail",
+        )
+    }
+
+    @Test
+    fun `safety net forces a reconcile when idle`() {
+        val g = gate()
+        drainUntilIdle(g, nowNanos = 0L)
+        assertFalse(g.shouldReconcile(nowNanos = (intervalSeconds - 1).toInt().secondsAsNanos))
+        assertTrue(
+            g.shouldReconcile(nowNanos = (intervalSeconds + 1).toInt().secondsAsNanos),
+            "safety net fires once the interval elapses",
+        )
+    }
+
+    @Test
+    fun `reconcileFailed re-arms so the next tick retries`() {
+        val g = gate()
+        drainUntilIdle(g, nowNanos = 0L)
+        // A notification wakes the gate; its reconcile then fails (throws).
+        g.markDirty()
+        assertTrue(g.shouldReconcile(nowNanos = 1.secondsAsNanos))
+        g.reconcileFailed()
+        assertTrue(g.shouldReconcile(nowNanos = 1.secondsAsNanos), "failure re-arms the retry")
+    }
+
+    @Test
+    fun `a notification landing during a reconcile survives the consume-before-work clear`() {
+        val g = gate()
+        drainUntilIdle(g, nowNanos = 0L)
+        // tick consumes the (absent) signal and finds idle
+        assertFalse(g.shouldReconcile(nowNanos = 1.secondsAsNanos))
+        // notification lands; even though a hypothetical in-flight pass already cleared its
+        // snapshot,
+        // the signal is recorded and honoured next tick.
+        g.markDirty()
+        g.reconcileSucceeded(insertedRows = 0, nowNanos = 1.secondsAsNanos)
+        assertTrue(g.shouldReconcile(nowNanos = 2.secondsAsNanos), "late notification is not lost")
+    }
+}

--- a/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/PgSubscriberTopicNotifier.kt
+++ b/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/PgSubscriberTopicNotifier.kt
@@ -2,6 +2,8 @@ package io.github.gabrielshanahan.scoop.quarkus
 
 import io.github.gabrielshanahan.scoop.messaging.TopicNotifier
 import io.vertx.pgclient.pubsub.PgSubscriber
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Implements [TopicNotifier] using Vert.x [PgSubscriber] for PostgreSQL LISTEN/NOTIFY.
@@ -9,11 +11,45 @@ import io.vertx.pgclient.pubsub.PgSubscriber
  * Callbacks are dispatched on virtual threads rather than the Vert.x event loop thread, because
  * consumers (e.g. [io.github.gabrielshanahan.scoop.coroutine.EventLoop.tick]) perform blocking JDBC
  * operations that are forbidden on event loop threads.
+ *
+ * ## Fan-out
+ *
+ * A Vert.x [io.vertx.pgclient.pubsub.PgChannel] has a *single* handler slot, and
+ * `pgSubscriber.channel(name)` returns the same channel for a given name. Registering one Vert.x
+ * handler per [onMessage] call would therefore let the last subscriber to a topic silently
+ * overwrite the handlers of all earlier subscribers — so only one of several workers/sagas on the
+ * same topic (in the same JVM) would ever be notified. To avoid depending on that behaviour, this
+ * notifier owns the fan-out: it registers exactly one Vert.x handler per topic and dispatches each
+ * notification to every callback currently registered for that topic.
  */
 class PgSubscriberTopicNotifier(private val pgSubscriber: PgSubscriber) : TopicNotifier {
+
+    private val callbacksByTopic = ConcurrentHashMap<String, CopyOnWriteArrayList<() -> Unit>>()
+
     override fun onMessage(topic: String, callback: () -> Unit): AutoCloseable {
-        val channel = pgSubscriber.channel(topic)
-        channel.handler { Thread.startVirtualThread(callback) }
-        return AutoCloseable { channel.handler(null) }
+        val callbacks =
+            callbacksByTopic.computeIfAbsent(topic) { topicName ->
+                val list = CopyOnWriteArrayList<() -> Unit>()
+                // One Vert.x handler per topic, dispatching to every registered callback. Each
+                // callback runs on its own virtual thread (off the Vert.x event loop, see class
+                // doc).
+                pgSubscriber.channel(topicName).handler {
+                    list.forEach { cb -> Thread.startVirtualThread(cb) }
+                }
+                list
+            }
+        callbacks.add(callback)
+
+        return AutoCloseable {
+            // Removing the callback is enough to stop it firing. The per-topic Vert.x handler is
+            // left
+            // in place even when the list empties: nulling it would race a concurrent re-subscribe
+            // on
+            // the shared PgChannel handler slot, and an empty list dispatches to nobody — a
+            // harmless
+            // no-op. PgSubscriber is application-scoped, so the residual idle handler lives only as
+            // long as the app.
+            callbacks.remove(callback)
+        }
     }
 }

--- a/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/ScoopProducer.kt
+++ b/scoop-quarkus/src/main/kotlin/io/github/gabrielshanahan/scoop/quarkus/ScoopProducer.kt
@@ -36,6 +36,14 @@ class ScoopProducer(
     private val dataSource: DataSource,
     @ConfigProperty(name = "scoop.tick-interval-ms", defaultValue = "50")
     private val tickIntervalMs: Long,
+    // Upper bound on reconciliation staleness when no NOTIFY arrives — the safety-net sweep
+    // interval
+    // (see ReconcileGate). Reconciliation normally runs on demand (driven by LISTEN/NOTIFY); this
+    // is
+    // the worst-case recovery latency for a missed notification. Default 30s; lower it to tighten
+    // recovery at the cost of more idle reconciles.
+    @ConfigProperty(name = "scoop.reconcile.safety-net-interval", defaultValue = "30s")
+    private val reconcileSafetyNet: Duration,
     // Exponential backoff between retries after a ScoopInfrastructureException (Scoop's own
     // bookkeeping failed, e.g. a dead connection — never a saga-logic failure, so never a
     // rollback).
@@ -127,6 +135,7 @@ class ScoopProducer(
             messageRepository,
             eventLoop,
             Duration.ofMillis(tickIntervalMs),
+            reconcileSafetyNet,
         )
 
     /**

--- a/scoop-quarkus/src/main/resources/db/migration/V5__notify_on_rollback_emitted.sql
+++ b/scoop-quarkus/src/main/resources/db/migration/V5__notify_on_rollback_emitted.sql
@@ -1,0 +1,38 @@
+-- Fire a LISTEN/NOTIFY when a ROLLBACK_EMITTED event is inserted, so that rollbacks become
+-- event-driven exactly like ordinary emissions.
+--
+-- Background: ordinary emissions INSERT a row into `message`, whose AFTER INSERT trigger
+-- (notify_message_insert, see V1) does pg_notify(topic, message_id). That notification is what lets
+-- the event loop reconcile EMITTED→SEEN on demand instead of polling every tick.
+--
+-- A ROLLBACK_EMITTED event, however, is a `message_event` row that REUSES an existing message_id —
+-- it does NOT insert into `message`, so it fires no notification. Without one, the
+-- ROLLBACK_EMITTED→ROLLING_BACK reconciliation could only be picked up by the periodic safety-net
+-- sweep once reconciliation is gated on notifications. This trigger restores prompt, NOTIFY-driven
+-- rollback start by emitting the same (channel = topic, payload = message_id) notification the
+-- message trigger does, so the existing per-topic listeners pick it up with no application change.
+--
+-- The notification only fires for ROLLBACK_EMITTED (a rare event); the constant SEEN / SUSPENDED /
+-- COMMITTED / ... churn pays only the cheap WHEN check and never notifies. ROLLING_BACK (which this
+-- reconciliation inserts) is not ROLLBACK_EMITTED, so there is no notification loop.
+
+CREATE OR REPLACE FUNCTION notify_rollback_emitted()
+    RETURNS TRIGGER AS $$
+DECLARE
+    v_topic text;
+BEGIN
+    -- The referenced message always exists and is immutable: ROLLBACK_EMITTED reuses the message_id
+    -- of an already-committed emission.
+    SELECT topic INTO v_topic FROM message WHERE id = NEW.message_id;
+    IF v_topic IS NOT NULL THEN
+        PERFORM pg_notify(v_topic, NEW.message_id::text);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER message_event_rollback_emitted_notify_trigger
+    AFTER INSERT ON message_event
+    FOR EACH ROW
+    WHEN (NEW.type = 'ROLLBACK_EMITTED')
+    EXECUTE FUNCTION notify_rollback_emitted();

--- a/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/MultiHandlerTopicNotifyTest.kt
+++ b/scoop-quarkus/src/test/kotlin/io/github/gabrielshanahan/scoop/messaging/MultiHandlerTopicNotifyTest.kt
@@ -1,0 +1,70 @@
+package io.github.gabrielshanahan.scoop.messaging
+
+import io.github.gabrielshanahan.scoop.coroutine.StructuredCooperationTest
+import io.github.gabrielshanahan.scoop.coroutine.builder.saga
+import io.github.gabrielshanahan.scoop.transactional
+import io.quarkus.test.junit.QuarkusTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Two *distinct* sagas subscribed to the *same* topic must both be woken by a single message's
+ * NOTIFY — and promptly, well inside the reconcile safety-net interval.
+ *
+ * This guards the fan-out in [io.github.gabrielshanahan.scoop.quarkus.PgSubscriberTopicNotifier]: a
+ * Vert.x `PgChannel` has a single handler slot, so without per-topic fan-out the second `subscribe`
+ * would overwrite the first's NOTIFY handler. With reconciliation gated on notifications, the
+ * overwritten saga would then only reconcile on the safety-net sweep — its `SEEN` (and thus this
+ * test's second latch) would be delayed by tens of seconds instead of one NOTIFY hop.
+ */
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MultiHandlerTopicNotifyTest : StructuredCooperationTest() {
+
+    @Test
+    fun `both sagas on one topic are notified promptly by a single message`() {
+        val latchA = CountDownLatch(1)
+        val latchB = CountDownLatch(1)
+
+        val subA =
+            messageQueue.subscribe(
+                rootTopic,
+                saga("handler-a", handlerRegistry.eventLoopStrategy()) {
+                    step { _, _ -> latchA.countDown() }
+                },
+            )
+        val subB =
+            messageQueue.subscribe(
+                rootTopic,
+                saga("handler-b", handlerRegistry.eventLoopStrategy()) {
+                    step { _, _ -> latchB.countDown() }
+                },
+            )
+
+        try {
+            val payload = jsonbHelper.toPGobject(mapOf("k" to "v"))
+            fluentJdbc.transactional { connection ->
+                messageQueue.launch(connection, rootTopic, payload)
+            }
+
+            // 5s is far below the 30s safety net but ample for a NOTIFY-driven reconcile + resume,
+            // so
+            // a pass here means both handlers were woken by the notification, not by the safety
+            // net.
+            assertTrue(
+                latchA.await(5, TimeUnit.SECONDS),
+                "handler-a should run within one NOTIFY hop",
+            )
+            assertTrue(
+                latchB.await(5, TimeUnit.SECONDS),
+                "handler-b should run within one NOTIFY hop",
+            )
+        } finally {
+            subA.close()
+            subB.close()
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The first half of every event-loop tick — `startContinuationsForCoroutine`, the `EMITTED→SEEN` / `ROLLBACK_EMITTED→ROLLING_BACK` anti-joins over `message_event` — runs on **every tick of every subscribed worker**, regardless of whether anything was emitted. With N idle topics at a fast tick interval this is the dominant idle cost: on one ~48-topic deployment at a 500 ms tick it was ~58% of a fully-utilised core doing nothing. The anti-joins are only ever non-empty on a tick that follows a `NOTIFY` for the topic.

## Change

Gate reconciliation on a per-worker signal (`ReconcileGate`) set by the same `LISTEN/NOTIFY` that already wakes the loop. A worker reconciles only after a notification for its topic, plus a rare safety-net sweep. Idle topics now do ~zero reconciliation scans.

- **Correctness never depends on `NOTIFY`.** A configurable safety-net sweep (`scoop.reconcile.safety-net-interval`, default `30s`) still forces a reconcile, preserving Scoop's "correct without `LISTEN/NOTIFY` at all" guarantee. It is the worst-case recovery latency for any missed notification (dropped `LISTEN`, server crash wiping the async-notify queue, lock contention).
- **The resume half of the tick is unchanged** — it still runs every tick, so time-based resumption (deadlines/sleep) and missed-notification recovery are unaffected.
- **No application code changes required** to benefit.

### Supporting changes (all required for correctness under load)

1. **`V5__notify_on_rollback_emitted.sql`** — a `ROLLBACK_EMITTED` reuses an existing message id and inserts no `message` row, so it fired no notification. Without it, gated reconciliation would only start rollbacks on the safety-net sweep. The trigger restores prompt, event-driven rollback start, symmetric with ordinary emissions. **Applied automatically by the bundled Flyway migrations.**
2. **`PgSubscriberTopicNotifier` fan-out** — a Vert.x `PgChannel` has a single handler slot and `channel(name)` is shared per name, so the last subscriber to a topic silently overwrote earlier ones' `NOTIFY` handlers. Masked while reconciliation ran every tick; under gating an overwritten *distinct* saga on a shared topic would start only on the safety net. The notifier now owns the fan-out (one Vert.x handler per topic dispatching to every registered callback).
3. **Drain-until-quiet** — sibling handlers reconciling messages under the same parent contend on that parent's `SEEN` row via `FOR UPDATE SKIP LOCKED`; the loser inserts nothing on the contended pass and would be stranded until the safety net if reconciliation ran exactly once per notification. `startContinuationsForCoroutine` now returns the rows-inserted count, and the gate keeps reconciling until *N consecutive zero-insert passes* (any productive pass resets the tail), so an arbitrary fan-out of contending siblings drains in order.

`ReconcileGate` uses a monotonic clock for the safety-net timer and seeds the first sweep with per-worker jitter to avoid a synchronized reconcile herd at fleet boot.

## Tests

- `ReconcileGateTest` (scoop-core, deterministic clock): drain tail, productive-pass reset, markDirty re-arm, safety-net firing, failure re-arm, late-notification-not-lost.
- `MultiHandlerTopicNotifyTest` (scoop-quarkus): two distinct sagas on one topic are both started promptly by a single message — guards the notifier fan-out under gating.
- Full existing suite green at `CI_TIMEOUT_MULTIPLIER=3` and at default timeouts.

## Adopter notes

- Apply migration **V5** (automatic via the provided Flyway setup).
- Optionally tune **`scoop.reconcile.safety-net-interval`** (default `30s`): lower tightens worst-case recovery at the cost of more idle scans.
- If you run multiple *distinct* sagas on the *same* topic in one JVM, be on this version before reducing tick frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuhBgTC3nXB2bP8oyS2QTp